### PR TITLE
Align exposure and temporal history with per-camera state

### DIFF
--- a/Editor/RenderPipeline/PostProcessing/ExposureEditor.cs
+++ b/Editor/RenderPipeline/PostProcessing/ExposureEditor.cs
@@ -37,6 +37,8 @@ namespace Illusion.Rendering.Editor
 
         private SerializedDataParameter _targetMidGray;
 
+        private SerializedDataParameter _sceneViewPreferFixedExposure;
+
         private int _repaintsAfterChange;
         private int _settingsForDoubleRefreshHash;
 
@@ -72,11 +74,15 @@ namespace Illusion.Rendering.Editor
             _proceduralMaxIntensity = Unpack(o.Find(x => x.maskMaxIntensity));
 
             _targetMidGray = Unpack(o.Find(x => x.targetMidGray));
+            _sceneViewPreferFixedExposure = Unpack(o.Find(x => x.sceneViewPreferFixedExposure));
         }
 
         public override void OnInspectorGUI()
         {
             PropertyField(_mode);
+            EditorGUILayout.Space();
+            EditorGUILayout.HelpBox("Scene View can use a fixed exposure fallback instead of sharing histogram auto exposure behavior with Game cameras.", MessageType.Info);
+            PropertyField(_sceneViewPreferFixedExposure, EditorGUIUtility.TrTextContent("Prefer Fixed Exposure"));
 
             int mode = _mode.value.intValue;
             // if (mode == (int)ExposureMode.UsePhysicalCamera)

--- a/Runtime/RenderPipeline/IllusionRendererData.Exposure.cs
+++ b/Runtime/RenderPipeline/IllusionRendererData.Exposure.cs
@@ -9,7 +9,7 @@ namespace Illusion.Rendering
     {
         private static void SetExposureTextureToEmpty(RTHandle exposureTexture)
         {
-            var tex = new Texture2D(1, 1, GraphicsFormat.R16G16_SFloat, TextureCreationFlags.None);
+            var tex = new Texture2D(1, 1, ExposureFormat, TextureCreationFlags.None);
             tex.SetPixel(0, 0, new Color(1f, ColorUtils.ConvertExposureToEV100(1f), 0f, 0f));
             tex.Apply();
             Graphics.Blit(tex, exposureTexture);
@@ -66,12 +66,49 @@ namespace Illusion.Rendering
         public bool IsExposureFixed()
         {
             if (_exposure == null) return true;
-            return _exposure.mode.value == ExposureMode.Fixed;
+            return _exposure.mode.value == ExposureMode.Fixed || UseSceneViewFixedExposureFallback();
             // || _automaticExposure.mode.value == ExposureMode.UsePhysicalCamera;
         }
         
         public bool CanRunFixedExposurePass() => IsExposureFixed()
                                                  && CurrentExposureTextures.Current != null;
+
+        public RTHandle GetFixedExposureOutputTexture()
+        {
+            return CurrentExposureTextures.Current;
+        }
+
+        public void GetFixedExposureParameters(out Vector4 exposureParams, out Vector4 exposureParams2)
+        {
+            float fixedExposure = 0.0f;
+            float compensation = 0.0f;
+
+            if (_exposure != null)
+            {
+                fixedExposure = _exposure.fixedExposure.value;
+                compensation = _exposure.compensation.value;
+
+                if (_exposure.mode.value != ExposureMode.Fixed && UseSceneViewFixedExposureFallback())
+                {
+                    fixedExposure = (_exposure.limitMin.value + _exposure.limitMax.value) * 0.5f;
+                }
+            }
+
+            exposureParams = new Vector4(compensation, fixedExposure, 0.0f, 0.0f);
+            exposureParams2 = new Vector4(0.0f, 0.0f, ColorUtils.lensImperfectionExposureScale,
+                ColorUtils.s_LightMeterCalibrationConstant);
+        }
+
+        private bool UseSceneViewFixedExposureFallback()
+        {
+            if (_camera == null || _camera.cameraType != CameraType.SceneView || _exposure == null)
+                return false;
+
+            if (_exposure.sceneViewPreferFixedExposure.overrideState)
+                return _exposure.sceneViewPreferFixedExposure.value;
+
+            return IllusionRuntimeRenderingConfig.Get().SceneViewPreferFixedExposure;
+        }
 
         /// <summary>
         /// Get RTHandle wrapper for Texture2D.whiteTexture (lazy initialization)
@@ -122,9 +159,7 @@ namespace Illusion.Rendering
             }
         }
 
-        private ExposureTextures _exposureTextures = new() {Current = null, Previous = null };
-
-        private ExposureTextures CurrentExposureTextures => _exposureTextures;
+        private ExposureTextures CurrentExposureTextures => _currentCameraState?.ExposureTextures ?? default;
 
         private void SetupExposureTextures()
         {
@@ -146,8 +181,11 @@ namespace Illusion.Rendering
 
             // One frame delay + history RTs being flipped at the beginning of the frame means we
             // have to grab the exposure marked as "previous"
-            _exposureTextures.Current = GetPreviousFrameRT((int)IllusionFrameHistoryType.Exposure);
-            _exposureTextures.Previous = currentTexture;
+            _currentCameraState.ExposureTextures = new ExposureTextures
+            {
+                Current = GetPreviousFrameRT((int)IllusionFrameHistoryType.Exposure),
+                Previous = currentTexture
+            };
         }
     }
 }

--- a/Runtime/RenderPipeline/IllusionRendererData.cs
+++ b/Runtime/RenderPipeline/IllusionRendererData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
@@ -129,7 +130,15 @@ namespace Illusion.Rendering
 
         public Vector2Int DepthMipChainSize => DepthMipChainInfo.textureSize;
 
-        public int ColorPyramidHistoryMipCount { get; internal set; }
+        public int ColorPyramidHistoryMipCount
+        {
+            get => _currentCameraState?.ColorPyramidHistoryMipCount ?? 1;
+            internal set
+            {
+                if (_currentCameraState != null)
+                    _currentCameraState.ColorPyramidHistoryMipCount = value;
+            }
+        }
 
         public readonly GPUCopy GPUCopy;
 
@@ -172,9 +181,9 @@ namespace Illusion.Rendering
         public TextureHandle ScreenSpaceReflectionTexture;
 
         /// <summary>
-        /// Get per-renderer frame count.
+        /// Get current camera frame count.
         /// </summary>
-        public uint FrameCount { get; private set; }
+        public uint FrameCount => _currentCameraState?.FrameCount ?? 0;
 
         /// <summary>
         /// Renderer requires a history color buffer.
@@ -211,11 +220,27 @@ namespace Illusion.Rendering
         /// </summary>
         public bool EnableIndirectDiffuseRenderingLayers { get; internal set; }
 
-        public bool IsFirstFrame { get; private set; } = true;
+        public bool IsFirstFrame => _currentCameraState == null || _currentCameraState.IsFirstFrame;
 
-        public bool ResetPostProcessingHistory { get; internal set; } = true;
+        public bool ResetPostProcessingHistory
+        {
+            get => _currentCameraState == null || _currentCameraState.ResetPostProcessingHistory;
+            internal set
+            {
+                if (_currentCameraState != null)
+                    _currentCameraState.ResetPostProcessingHistory = value;
+            }
+        }
 
-        public bool DidResetPostProcessingHistoryInLastFrame { get; internal set; }
+        public bool DidResetPostProcessingHistoryInLastFrame
+        {
+            get => _currentCameraState != null && _currentCameraState.DidResetPostProcessingHistoryInLastFrame;
+            internal set
+            {
+                if (_currentCameraState != null)
+                    _currentCameraState.DidResetPostProcessingHistoryInLastFrame = value;
+            }
+        }
 
         /// <summary>
         /// Returns true if lighting is active for current state of debug settings.
@@ -248,15 +273,75 @@ namespace Illusion.Rendering
 
         public static IllusionRendererData Active { get; private set; }
 
+        internal ref SsgiHistoryState CurrentSsgiHistoryState => ref _currentCameraState.SsgiHistory;
+
+        internal ref ScreenSpaceShadowTemporalState CurrentScreenSpaceShadowTemporalState =>
+            ref _currentCameraState.ScreenSpaceShadowTemporal;
+
+        internal ref ScreenSpaceReflectionHistoryState CurrentScreenSpaceReflectionHistoryState =>
+            ref _currentCameraState.ScreenSpaceReflection;
+
         private UniversalAdditionalCameraData _additionalCameraData;
 
-        private readonly BufferedRTHandleSystem _historyRTSystem = new();
+        private const int StaleCameraStateFrameThreshold = 600;
+
+        internal struct SsgiHistoryState
+        {
+            public float HistoryResolutionScale0;
+            public float HistoryResolutionScale1;
+            public bool HasHistory0State;
+            public bool HasHistory1State;
+            public uint LastHistory0FrameCount;
+            public uint LastHistory1FrameCount;
+        }
+
+        internal struct ScreenSpaceShadowTemporalState
+        {
+            public bool HasDirectionalHistoryState;
+            public Vector3 LastMainLightDirection;
+            public uint LastHistoryFrameCount;
+        }
+
+        internal struct ScreenSpaceReflectionHistoryState
+        {
+            public float AccumulationResolutionScale;
+            public ScreenSpaceReflectionAlgorithm CurrentAlgorithm;
+        }
+
+        private sealed class CameraRenderState
+        {
+            public readonly BufferedRTHandleSystem HistoryRTSystem = new();
+            public ExposureTextures ExposureTextures;
+            public uint FrameCount;
+            public bool IsFirstFrame = true;
+            public bool ResetPostProcessingHistory = true;
+            public bool DidResetPostProcessingHistoryInLastFrame;
+            public int TaaFrameIndex;
+            public Matrix4x4 PreviousInvViewProjMatrix;
+            public int ColorPyramidHistoryMipCount = 1;
+            public int LastUsedFrame;
+            public SsgiHistoryState SsgiHistory;
+            public ScreenSpaceShadowTemporalState ScreenSpaceShadowTemporal;
+            public ScreenSpaceReflectionHistoryState ScreenSpaceReflection =
+                new ScreenSpaceReflectionHistoryState { CurrentAlgorithm = ScreenSpaceReflectionAlgorithm.Approximation };
+
+            public void Dispose()
+            {
+                HistoryRTSystem.Dispose();
+            }
+        }
+
+        private readonly Dictionary<Camera, CameraRenderState> _cameraStates = new();
+
+        private readonly List<Camera> _staleCameraStateKeys = new();
+
+        private CameraRenderState _currentCameraState;
 
         private Camera _camera;
 
         private Exposure _exposure;
 
-        private readonly RTHandle _emptyExposureTexture; // RGHalf
+        private readonly RTHandle _emptyExposureTexture; // RGFloat
 
         private readonly RTHandle _debugExposureData;
         
@@ -265,8 +350,6 @@ namespace Illusion.Rendering
         private RTHandle _blackTextureRTHandle;
         
         private RTHandle _grayTextureRTHandle;
-
-        private int _taaFrameIndex;
 
         private UniversalAdditionalLightData _mainLightData;
 
@@ -315,6 +398,7 @@ namespace Illusion.Rendering
             // neutral exposure texture isn't 0
             _emptyExposureTexture = RTHandles.Alloc(1, 1, colorFormat: ExposureFormat,
                 enableRandomWrite: true, name: "Empty EV100 Exposure");
+            SetExposureTextureToEmpty(_emptyExposureTexture);
 
             _debugExposureData = RTHandles.Alloc(1, 1, colorFormat: ExposureFormat,
                 enableRandomWrite: true, name: "Debug Exposure Info");
@@ -331,10 +415,11 @@ namespace Illusion.Rendering
         public void Update(UniversalCameraData cameraData, UniversalLightData lightData, UniversalShadowData shadowData)
         {
             Active = this;
-            // Advance render frame
-            FrameCount++;
-            IsFirstFrame = false;
             UpdateCameraData(cameraData);
+            _currentCameraState = GetOrCreateCameraState(_camera);
+            _currentCameraState.FrameCount++;
+            _currentCameraState.IsFirstFrame = false;
+            PruneStaleCameraStates();
             UpdateLightData(lightData);
             UpdateShadowData(cameraData, lightData, shadowData);
             UpdateRenderTextures(cameraData);
@@ -350,7 +435,13 @@ namespace Illusion.Rendering
             }
 
             MipGenerator.Release();
-            _historyRTSystem.Dispose();
+            foreach (var cameraState in _cameraStates.Values)
+            {
+                cameraState.Dispose();
+            }
+            _cameraStates.Clear();
+            _staleCameraStateKeys.Clear();
+            _currentCameraState = null;
             CameraPreDepthTextureRT?.Release();
             CameraPreviousColorTextureRT?.Release();
             DepthPyramidMipLevelOffsetsBuffer?.Release();
@@ -367,6 +458,7 @@ namespace Illusion.Rendering
             CoreUtils.SafeRelease(DebugImageHistogram);
             DebugImageHistogram = null;
             RTHandles.Release(_emptyExposureTexture);
+            RTHandles.Release(_debugExposureData);
             
             // Release default texture RTHandle wrappers
             RTHandles.Release(_whiteTextureRTHandle);
@@ -387,32 +479,34 @@ namespace Illusion.Rendering
         private void PrepareGlobalVariables(UniversalCameraData cameraData, UniversalLightData lightData,  bool yFlip)
         {
             bool useTAA = cameraData.IsTemporalAAEnabled(); // Disable in scene view
+            var cameraState = _currentCameraState;
+            var historyRTSystem = cameraState.HistoryRTSystem;
             
             // Match HDRP View Projection Matrix, pre-handle reverse z.
             _shaderVariablesGlobal.ViewMatrix = cameraData.camera.worldToCameraMatrix;
             _shaderVariablesGlobal.ViewProjMatrix = IllusionRenderingUtils.CalculateViewProjMatrix(cameraData, yFlip);
             _shaderVariablesGlobal.InvProjMatrix = cameraData.GetGPUProjectionMatrix(true).inverse;
-            var previousInvViewProjMatrix = _shaderVariablesGlobal.InvViewProjMatrix;
             _shaderVariablesGlobal.InvViewProjMatrix = _shaderVariablesGlobal.ViewProjMatrix.inverse;
             _shaderVariablesGlobal.PrevInvViewProjMatrix = FrameCount <= 1 || ResetPostProcessingHistory
                 ? _shaderVariablesGlobal.InvViewProjMatrix
-                : previousInvViewProjMatrix;
+                : cameraState.PreviousInvViewProjMatrix;
+            cameraState.PreviousInvViewProjMatrix = _shaderVariablesGlobal.InvViewProjMatrix;
 
             // No RTHandleScale in IllusionRP
             // _shaderVariablesGlobal.RTHandleScale = RTHandles.rtHandleProperties.rtHandleScale;
-            // _shaderVariablesGlobal.RTHandleScaleHistory = _historyRTSystem.rtHandleProperties.rtHandleScale;
+            // _shaderVariablesGlobal.RTHandleScaleHistory = historyRTSystem.rtHandleProperties.rtHandleScale;
 #if !UNITY_2023_1_OR_NEWER
             _shaderVariablesGlobal.RTHandleScale = Vector4.one;
 #endif
             _shaderVariablesGlobal.RTHandleScaleHistory = Vector4.one;
 
             const int kMaxSampleCount = 8;
-            if (++_taaFrameIndex >= kMaxSampleCount)
-                _taaFrameIndex = 0;
-            _shaderVariablesGlobal.TaaFrameInfo = new Vector4(0, _taaFrameIndex, FrameCount, useTAA ? 1 : 0);
+            if (++cameraState.TaaFrameIndex >= kMaxSampleCount)
+                cameraState.TaaFrameIndex = 0;
+            _shaderVariablesGlobal.TaaFrameInfo = new Vector4(0, cameraState.TaaFrameIndex, FrameCount, useTAA ? 1 : 0);
             _shaderVariablesGlobal.ColorPyramidUvScaleAndLimitPrevFrame
-                = IllusionRenderingUtils.ComputeViewportScaleAndLimit(_historyRTSystem.rtHandleProperties.previousViewportSize,
-                    _historyRTSystem.rtHandleProperties.previousRenderTargetSize);
+                = IllusionRenderingUtils.ComputeViewportScaleAndLimit(historyRTSystem.rtHandleProperties.previousViewportSize,
+                    historyRTSystem.rtHandleProperties.previousRenderTargetSize);
             
             MicroShadows microShadowingSettings = VolumeManager.instance.stack.GetComponent<MicroShadows>();
             _shaderVariablesGlobal.MicroShadowOpacity = microShadowingSettings.enable.value ? microShadowingSettings.opacity.value : 0.0f;
@@ -490,14 +584,15 @@ namespace Illusion.Rendering
         {
             var descriptor = cameraData.cameraTargetDescriptor;
             var viewportSize = new Vector2Int(descriptor.width, descriptor.height);
-            _historyRTSystem.SwapAndSetReferenceSize(descriptor.width, descriptor.height);
+            var historyRTSystem = _currentCameraState.HistoryRTSystem;
+            historyRTSystem.SwapAndSetReferenceSize(descriptor.width, descriptor.height);
 
             // Since we do not use RTHandleScale, ensure render texture size correct
-            if (_historyRTSystem.rtHandleProperties.currentRenderTargetSize.x > descriptor.width
-                || _historyRTSystem.rtHandleProperties.currentRenderTargetSize.y > descriptor.height)
+            if (historyRTSystem.rtHandleProperties.currentRenderTargetSize.x > descriptor.width
+                || historyRTSystem.rtHandleProperties.currentRenderTargetSize.y > descriptor.height)
             {
-                _historyRTSystem.ResetReferenceSize(descriptor.width, descriptor.height);
-                _exposureTextures.Clear();
+                historyRTSystem.ResetReferenceSize(descriptor.width, descriptor.height);
+                _currentCameraState.ExposureTextures.Clear();
             }
 
             DepthMipChainInfo.ComputePackedMipChainInfo(viewportSize, 0);
@@ -531,6 +626,44 @@ namespace Illusion.Rendering
         {
             _camera = cameraData.camera;
             _camera.TryGetComponent(out _additionalCameraData);
+        }
+
+        private CameraRenderState GetOrCreateCameraState(Camera camera)
+        {
+            if (!_cameraStates.TryGetValue(camera, out var cameraState))
+            {
+                cameraState = new CameraRenderState();
+                _cameraStates.Add(camera, cameraState);
+            }
+
+            cameraState.LastUsedFrame = Time.frameCount;
+            return cameraState;
+        }
+
+        internal void SetColorPyramidHistoryMipCount(Camera camera, int mipCount)
+        {
+            GetOrCreateCameraState(camera).ColorPyramidHistoryMipCount = mipCount;
+        }
+
+        private void PruneStaleCameraStates()
+        {
+            _staleCameraStateKeys.Clear();
+            foreach (var pair in _cameraStates)
+            {
+                if (pair.Value == _currentCameraState)
+                    continue;
+
+                if (pair.Key == null || Time.frameCount - pair.Value.LastUsedFrame > StaleCameraStateFrameThreshold)
+                    _staleCameraStateKeys.Add(pair.Key);
+            }
+
+            foreach (var key in _staleCameraStateKeys)
+            {
+                if (_cameraStates.TryGetValue(key, out var cameraState))
+                    cameraState.Dispose();
+
+                _cameraStates.Remove(key);
+            }
         }
 
         private void UpdateLightData(UniversalLightData lightData)
@@ -631,10 +764,14 @@ namespace Illusion.Rendering
 
         public Vector4 EvaluateRayTracingHistorySizeAndScale(RTHandle buffer)
         {
-            return new Vector4(_historyRTSystem.rtHandleProperties.previousViewportSize.x,
-                _historyRTSystem.rtHandleProperties.previousViewportSize.y,
-                (float)_historyRTSystem.rtHandleProperties.previousViewportSize.x / buffer.rt.width,
-                (float)_historyRTSystem.rtHandleProperties.previousViewportSize.y / buffer.rt.height);
+            if (_currentCameraState == null || buffer?.rt == null)
+                return Vector4.one;
+
+            var properties = _currentCameraState.HistoryRTSystem.rtHandleProperties;
+            return new Vector4(properties.previousViewportSize.x,
+                properties.previousViewportSize.y,
+                (float)properties.previousViewportSize.x / buffer.rt.width,
+                (float)properties.previousViewportSize.y / buffer.rt.height);
         }
 
         /// <summary>
@@ -646,8 +783,9 @@ namespace Illusion.Rendering
         /// <returns>A new RTHandle.</returns>
         public RTHandle AllocHistoryFrameRT(int id, Func<string, int, RTHandleSystem, RTHandle> allocator, int bufferCount)
         {
-            _historyRTSystem.AllocBuffer(id, (rts, i) => allocator(_camera.name, i, rts), bufferCount);
-            return _historyRTSystem.GetFrameRT(id, 0);
+            var historyRTSystem = _currentCameraState.HistoryRTSystem;
+            historyRTSystem.AllocBuffer(id, (rts, i) => allocator(_camera.name, i, rts), bufferCount);
+            return historyRTSystem.GetFrameRT(id, 0);
         }
 
         /// <summary>
@@ -657,7 +795,7 @@ namespace Illusion.Rendering
         /// <returns>The RTHandle from previous frame.</returns>
         public RTHandle GetPreviousFrameRT(int id)
         {
-            return _historyRTSystem.GetFrameRT(id, 1);
+            return _currentCameraState?.HistoryRTSystem.GetFrameRT(id, 1);
         }
 
         /// <summary>
@@ -667,7 +805,7 @@ namespace Illusion.Rendering
         /// <returns>The RTHandle of the current frame.</returns>
         public RTHandle GetCurrentFrameRT(int id)
         {
-            return _historyRTSystem.GetFrameRT(id, 0);
+            return _currentCameraState?.HistoryRTSystem.GetFrameRT(id, 0);
         }
 
         /// <summary>
@@ -676,7 +814,7 @@ namespace Illusion.Rendering
         /// <param name="id"></param>
         internal void ReleaseHistoryFrameRT(int id)
         {
-            _historyRTSystem.ReleaseBuffer(id);
+            _currentCameraState?.HistoryRTSystem.ReleaseBuffer(id);
         }
 
         /// <summary>
@@ -693,7 +831,7 @@ namespace Illusion.Rendering
             if (cameraData.cameraType is CameraType.Game or CameraType.SceneView)
             {
                 var previewsColorRT = GetCurrentFrameRT((int)IllusionFrameHistoryType.ColorBufferMipChain);
-                if (previewsColorRT != null)
+                if (previewsColorRT != null && previewsColorRT.IsValid())
                 {
                     isNewFrame = true;
                     return previewsColorRT;

--- a/Runtime/RenderPipeline/IllusionRendererFeature.Setup.cs
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.Setup.cs
@@ -1,4 +1,6 @@
 using System;
+using Illusion.Rendering.PostProcessing;
+using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.RenderGraphModule;
 using UnityEngine.Rendering.Universal;
@@ -18,6 +20,8 @@ namespace Illusion.Rendering
 
             private RenderingData _renderingData;
 
+            private readonly ProfilingSampler _fixedExposureSampler = new("Fixed Exposure");
+
             public SetupPass(IllusionRendererFeature rendererFeature, IllusionRendererData rendererData)
             {
                 _rendererFeature = rendererFeature;
@@ -34,6 +38,17 @@ namespace Illusion.Rendering
                 internal TextureHandle ActiveColor;
                 internal TextureHandle PreviousFrameColor;
                 internal TextureHandle MotionVectorColor;
+                internal TextureHandle CurrentExposureTexture;
+                internal TextureHandle PreviousExposureTexture;
+            }
+
+            private class FixedExposurePassData
+            {
+                internal ComputeShader ExposureCS;
+                internal int Kernel;
+                internal Vector4 ExposureParams;
+                internal Vector4 ExposureParams2;
+                internal TextureHandle OutputTexture;
             }
 
             public override void RecordRenderGraph(RenderGraph renderGraph,  ContextContainer frameData)
@@ -43,6 +58,28 @@ namespace Illusion.Rendering
                 
                 _rendererFeature.PerformSetup(frameData, _rendererData);
                 _rendererData.BindDitheredRNGData1SPP(renderGraph);
+
+                if (_rendererData.CanRunFixedExposurePass())
+                {
+                    using var builder = renderGraph.AddComputePass<FixedExposurePassData>("Fixed Exposure", out var exposureData,
+                        _fixedExposureSampler);
+                    exposureData.ExposureCS = _rendererData.RuntimeResources.exposureCS;
+                    exposureData.Kernel = exposureData.ExposureCS.FindKernel("KFixedExposure");
+                    _rendererData.GetFixedExposureParameters(out exposureData.ExposureParams, out exposureData.ExposureParams2);
+
+                    var exposureOutput = renderGraph.ImportTexture(_rendererData.GetFixedExposureOutputTexture());
+                    builder.UseTexture(exposureOutput, AccessFlags.Write);
+                    exposureData.OutputTexture = exposureOutput;
+                    builder.AllowPassCulling(false);
+
+                    builder.SetRenderFunc(static (FixedExposurePassData data, ComputeGraphContext context) =>
+                    {
+                        context.cmd.SetComputeVectorParam(data.ExposureCS, ExposureShaderIDs._ExposureParams, data.ExposureParams);
+                        context.cmd.SetComputeVectorParam(data.ExposureCS, ExposureShaderIDs._ExposureParams2, data.ExposureParams2);
+                        context.cmd.SetComputeTextureParam(data.ExposureCS, data.Kernel, ExposureShaderIDs._OutputTexture, data.OutputTexture);
+                        context.cmd.DispatchCompute(data.ExposureCS, data.Kernel, 1, 1, 1);
+                    });
+                }
                 
                 using (var builder = renderGraph.AddRasterRenderPass<SetGlobalVariablesPassData>("Set Global Variables", out var passData, profilingSampler))
                 {
@@ -56,7 +93,7 @@ namespace Illusion.Rendering
                     passData.LightData = lightData;
                     
                     var previousFrameRT = _rendererData.GetPreviousFrameColorRT(frameData, out _);
-                    if (!previousFrameRT.IsValid()) previousFrameRT = _rendererData.GetBlackTextureRT();
+                    if (previousFrameRT == null || !previousFrameRT.IsValid()) previousFrameRT = _rendererData.GetBlackTextureRT();
                     
                     passData.PreviousFrameColor = renderGraph.ImportTexture(previousFrameRT);
                     builder.UseTexture(passData.PreviousFrameColor);
@@ -64,6 +101,11 @@ namespace Illusion.Rendering
                     var motionVectorColorRT = resource.motionVectorColor;
                     passData.MotionVectorColor = motionVectorColorRT;
                     builder.UseTexture(motionVectorColorRT);
+
+                    passData.CurrentExposureTexture = renderGraph.ImportTexture(_rendererData.GetExposureTexture());
+                    builder.UseTexture(passData.CurrentExposureTexture);
+                    passData.PreviousExposureTexture = renderGraph.ImportTexture(_rendererData.GetPreviousExposureTexture());
+                    builder.UseTexture(passData.PreviousExposureTexture);
                     
                     builder.AllowPassCulling(false);
                     builder.AllowGlobalStateModification(true);
@@ -74,6 +116,8 @@ namespace Illusion.Rendering
                         data.RendererData.PushGlobalBuffers(context.cmd, data.CameraData, data.LightData, yFlip);
                         context.cmd.SetGlobalTexture(IllusionShaderProperties._HistoryColorTexture, data.PreviousFrameColor);
                         context.cmd.SetGlobalTexture(IllusionShaderProperties._MotionVectorTexture, data.MotionVectorColor);
+                        context.cmd.SetGlobalTexture(IllusionShaderProperties._ExposureTexture, data.CurrentExposureTexture);
+                        context.cmd.SetGlobalTexture(IllusionShaderProperties._PrevExposureTexture, data.PreviousExposureTexture);
                         data.RendererData.BindAmbientProbe(context.cmd);
                     });
                 }

--- a/Runtime/RenderPipeline/IllusionRendererFeature.cs
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.cs
@@ -502,7 +502,7 @@ namespace Illusion.Rendering
             }
             else
             {
-                _rendererData.ColorPyramidHistoryMipCount = 1;
+                _rendererData.SetColorPyramidHistoryMipCount(renderingData.cameraData.camera, 1);
             }
 
             // BeforeRenderingPostProcessing

--- a/Runtime/RenderPipeline/IllusionRuntimeRenderingConfig.cs
+++ b/Runtime/RenderPipeline/IllusionRuntimeRenderingConfig.cs
@@ -63,6 +63,12 @@ namespace Illusion.Rendering
         public bool EnableConvolutionBloom { get; set; } = true;
 
         /// <summary>
+        /// When the Exposure volume does not override Scene View behavior, Scene View cameras use fixed exposure fallback instead of histogram auto exposure.
+        /// </summary>
+        [ConfigVariable("r.sceneview.exposure.fixedfallback", IsEditor = true)]
+        public bool SceneViewPreferFixedExposure { get; set; } = true;
+
+        /// <summary>
         /// Whether enable Async Compute.
         /// </summary>
         // [ConfigVariable("r.asynccompute")]

--- a/Runtime/RenderPipeline/PostProcessing/Exposure/Exposure.cs
+++ b/Runtime/RenderPipeline/PostProcessing/Exposure/Exposure.cs
@@ -131,6 +131,13 @@ namespace Illusion.Rendering.PostProcessing
         [Tooltip("Sets the desired Mid gray level used by the auto exposure (i.e. to what grey value the auto exposure system maps the average scene luminance).")]
         public TargetMidGrayParameter targetMidGray = new(TargetMidGray.Grey125);
 
+        /// <summary>
+        /// Uses a fixed exposure fallback for Scene View cameras when histogram exposure would otherwise run.
+        /// </summary>
+        [Header("Scene View")]
+        [Tooltip("Uses a fixed exposure fallback for Scene View cameras when histogram exposure would otherwise run.")]
+        public BoolParameter sceneViewPreferFixedExposure = new(false);
+
         // /// <summary>
         // /// Sets whether the procedural metering mask is centered around the exposure target (to be set on the camera)
         // /// </summary>

--- a/Runtime/RenderPipeline/PostProcessing/Exposure/ExposureDebugPass.cs
+++ b/Runtime/RenderPipeline/PostProcessing/Exposure/ExposureDebugPass.cs
@@ -21,8 +21,6 @@ namespace Illusion.Rendering.PostProcessing
         private Exposure _exposure;
 
         private readonly LazyMaterial _debugExposureMaterial = new(IllusionShaders.DebugExposure);
-        
-        private ComputeBuffer _histogramBuffer;
 
         private readonly IllusionRendererData _rendererData;
         
@@ -31,12 +29,15 @@ namespace Illusion.Rendering.PostProcessing
         
         private RTHandle _debugFontTexRTHandle;
 
+        private Texture _cachedWeightTextureMask;
+
         private class DebugHistogramPassData
         {
             internal ComputeShader DebugImageHistogramCs;
             internal int DebugImageHistogramKernel;
             internal TextureHandle SourceTexture;
             internal ComputeBuffer HistogramBuffer;
+            internal int[] EmptyHistogram;
             internal int CameraWidth;
             internal int CameraHeight;
         }
@@ -84,7 +85,6 @@ namespace Illusion.Rendering.PostProcessing
         {
             _exposure = VolumeManager.instance.stack.GetComponent<Exposure>();
             IllusionRenderingUtils.ValidateComputeBuffer(ref _rendererData.DebugImageHistogram, DebugImageHistogramBins, 4 * sizeof(uint));
-            _rendererData.DebugImageHistogram.SetData(_emptyDebugImageHistogram);    // Clear the histogram
             
             var descriptor = cameraData.cameraTargetDescriptor;
             descriptor.depthBufferBits = (int)DepthBits.None;
@@ -102,6 +102,8 @@ namespace Illusion.Rendering.PostProcessing
 
             // Import textures
             var colorBeforePostProcess = _rendererData.GetPreviousFrameColorRT(frameData, out _);
+            if (colorBeforePostProcess == null || !colorBeforePostProcess.IsValid())
+                colorBeforePostProcess = _rendererData.GetBlackTextureRT();
             TextureHandle sourceBeforePostProcess = renderGraph.ImportTexture(colorBeforePostProcess);
             TextureHandle colorTarget = resource.cameraColor;
             TextureHandle debugOutputTexture = renderGraph.ImportTexture(_rendererData.DebugExposureTexture);
@@ -113,6 +115,7 @@ namespace Illusion.Rendering.PostProcessing
                 data.DebugImageHistogramCs = _debugImageHistogramCs;
                 data.DebugImageHistogramKernel = _debugImageHistogramKernel;
                 data.HistogramBuffer = _rendererData.DebugImageHistogram;
+                data.EmptyHistogram = _emptyDebugImageHistogram;
                 data.CameraWidth = cameraData.camera.pixelWidth;
                 data.CameraHeight = cameraData.camera.pixelHeight;
 
@@ -135,6 +138,11 @@ namespace Illusion.Rendering.PostProcessing
                 
                 builder.UseTexture(colorTarget);
                 data.SourceTexture = colorTarget;
+                builder.UseTexture(data.CurrentExposure);
+                builder.UseTexture(data.PreviousExposure);
+                builder.UseTexture(data.ExposureDebugData);
+                builder.UseTexture(data.WeightTextureMask);
+                builder.UseTexture(data.DebugFontTex);
                 
                 builder.SetRenderAttachment(debugOutputTexture, 0);
 
@@ -187,7 +195,7 @@ namespace Illusion.Rendering.PostProcessing
             
             // Import Texture2D resources as TextureHandle with cached RTHandle wrappers
             var currentWeightMask = _exposure.weightTextureMask.value;
-            if (_weightTextureMaskRTHandle == null || currentWeightMask == null)
+            if (_weightTextureMaskRTHandle == null || _cachedWeightTextureMask != currentWeightMask)
             {
                 // Release old RTHandle if texture changed
                 if (_weightTextureMaskRTHandle != null)
@@ -201,6 +209,7 @@ namespace Illusion.Rendering.PostProcessing
                 {
                     _weightTextureMaskRTHandle = RTHandles.Alloc(currentWeightMask);
                 }
+                _cachedWeightTextureMask = currentWeightMask;
             }
             
             RTHandle weightMaskHandle = _weightTextureMaskRTHandle ?? _rendererData.GetWhiteTextureRT();
@@ -259,6 +268,7 @@ namespace Illusion.Rendering.PostProcessing
 
         private static void DoGenerateDebugImageHistogram(DebugHistogramPassData data, ComputeCommandBuffer cmd)
         {
+            cmd.SetBufferData(data.HistogramBuffer, data.EmptyHistogram);
             cmd.SetComputeTextureParam(data.DebugImageHistogramCs, data.DebugImageHistogramKernel, 
                 ExposureShaderIDs._SourceTexture, data.SourceTexture);
             cmd.SetComputeBufferParam(data.DebugImageHistogramCs, data.DebugImageHistogramKernel, 
@@ -313,6 +323,7 @@ namespace Illusion.Rendering.PostProcessing
             RTHandles.Release(_debugFontTexRTHandle);
             _weightTextureMaskRTHandle = null;
             _debugFontTexRTHandle = null;
+            _cachedWeightTextureMask = null;
         }
     }
 }

--- a/Runtime/RenderPipeline/PostProcessing/Exposure/ExposurePass.cs
+++ b/Runtime/RenderPipeline/PostProcessing/Exposure/ExposurePass.cs
@@ -58,8 +58,6 @@ namespace Illusion.Rendering.PostProcessing
         private readonly ComputeShader _exposureCS;
 
         private readonly IllusionRendererData _rendererData;
-        
-        private readonly ProfilingSampler _fixedExposureSampler = new("Fixed Exposure");
                 
         private readonly ProfilingSampler _automaticExposureSampler = new("Automatic Exposure");
         
@@ -67,6 +65,10 @@ namespace Illusion.Rendering.PostProcessing
         private RTHandle _textureMeteringMaskRTHandle;
         
         private RTHandle _exposureCurveRTHandle;
+
+        private Texture _cachedMeteringMaskTexture;
+
+        private Texture _cachedExposureCurveTexture;
 
         private class ExposurePassData
         {
@@ -100,6 +102,7 @@ namespace Illusion.Rendering.PostProcessing
             internal bool HistogramUsesCurve;
             internal bool HistogramOutputDebugData;
             internal bool ResetPostProcessingHistory;
+            internal int[] EmptyHistogram;
             
             internal int CameraWidth;
             internal int CameraHeight;
@@ -184,7 +187,6 @@ namespace Illusion.Rendering.PostProcessing
             // if (isHistogramBased)
             {
                 IllusionRenderingUtils.ValidateComputeBuffer(ref _rendererData.HistogramBuffer, HistogramBins, sizeof(uint));
-                _rendererData.HistogramBuffer.SetData(_emptyHistogram);    // Clear the histogram
 
                 Vector2 histogramFraction = _exposure.histogramPercentages.value / 100.0f;
                 float evRange = limitMax - limitMin;
@@ -195,6 +197,10 @@ namespace Illusion.Rendering.PostProcessing
                 if (_histogramOutputDebugData)
                 {
                     _histogramExposureCs.EnableKeyword("OUTPUT_DEBUG_DATA");
+                }
+                else
+                {
+                    _histogramExposureCs.DisableKeyword("OUTPUT_DEBUG_DATA");
                 }
             }
         }
@@ -268,6 +274,7 @@ namespace Illusion.Rendering.PostProcessing
         {
             var cs = data.HistogramExposureCs;
 
+            cmd.SetBufferData(data.HistogramBuffer, data.EmptyHistogram);
             cmd.SetComputeVectorParam(cs, ExposureShaderIDs._ProceduralMaskParams, data.ProceduralMaskParams);
             cmd.SetComputeVectorParam(cs, ExposureShaderIDs._ProceduralMaskParams2, data.ProceduralMaskParams2);
 
@@ -322,14 +329,18 @@ namespace Illusion.Rendering.PostProcessing
             PrepareExposureData(cameraData);
             
             bool isFixedExposure = _rendererData.CanRunFixedExposurePass();
+            if (isFixedExposure)
+            {
+                return;
+            }
+
             bool resetHistory = _rendererData.ResetPostProcessingHistory;
-            ProfilingSampler sampler = isFixedExposure ? _fixedExposureSampler : _automaticExposureSampler;
             
             // Main exposure pass
-            using (var builder = renderGraph.AddComputePass<ExposurePassData>("Exposure Pass", out var passData, sampler))
+            using (var builder = renderGraph.AddComputePass<ExposurePassData>("Exposure Pass", out var passData, _automaticExposureSampler))
             {
                 // Setup pass data
-                PreparePassDataForRenderGraph(builder, passData, frameData, isFixedExposure, renderGraph);
+                PreparePassDataForRenderGraph(builder, passData, frameData, false, renderGraph);
                 
                 _rendererData.GrabExposureRequiredTextures(out var prevExposure, out var nextExposure);
                 var preExposure = renderGraph.ImportTexture(prevExposure);
@@ -347,34 +358,12 @@ namespace Illusion.Rendering.PostProcessing
                     passData.ExposureDebugData = debugDataHandle;
                 }
                 
-                // Import textures for SetGlobalTexture
-                var currentExposureRT = _rendererData.GetExposureTexture();
-                var previousExposureRT = _rendererData.GetPreviousExposureTexture();
-                var currentExposureHandle = renderGraph.ImportTexture(currentExposureRT);
-                builder.UseTexture(currentExposureHandle);
-                passData.CurrentExposureTexture = currentExposureHandle;
-                var previousExposureHandle = renderGraph.ImportTexture(previousExposureRT);
-                builder.UseTexture(previousExposureHandle);
-                passData.PreviousExposureTexture = previousExposureHandle;
-                
                 builder.AllowPassCulling(false);
-                builder.AllowGlobalStateModification(true);
                 
                 // Set render function
                 builder.SetRenderFunc(static (ExposurePassData data, ComputeGraphContext context) =>
                 {
-                    if (data.IsFixedExposure)
-                    {
-                        DoFixedExposure(data, context.cmd);
-                    }
-                    else
-                    {
-                        DoHistogramBasedExposure(data, context.cmd);
-                    }
-                    
-                    // Set global textures using TextureHandle
-                    context.cmd.SetGlobalTexture(IllusionShaderProperties._ExposureTexture, data.CurrentExposureTexture);
-                    context.cmd.SetGlobalTexture(IllusionShaderProperties._PrevExposureTexture, data.PreviousExposureTexture);
+                    DoHistogramBasedExposure(data, context.cmd);
                 });
             }
             
@@ -439,10 +428,10 @@ namespace Illusion.Rendering.PostProcessing
                 passData.ExposurePreparationKernel = _exposurePreparationKernel;
                 passData.ExposureReductionKernel = _exposureReductionKernel;
                 
-                passData.ExposureVariants = _exposureVariants;
+                passData.ExposureVariants = (int[])_exposureVariants.Clone();
                 
                 // Import Texture2D resources as TextureHandle with cached RTHandle wrappers
-                if (_textureMeteringMaskRTHandle == null || _textureMeteringMask == null)
+                if (_textureMeteringMaskRTHandle == null || _cachedMeteringMaskTexture != _textureMeteringMask)
                 {
                     // Release old RTHandle if texture changed
                     if (_textureMeteringMaskRTHandle != null)
@@ -456,6 +445,7 @@ namespace Illusion.Rendering.PostProcessing
                     {
                         _textureMeteringMaskRTHandle = RTHandles.Alloc(_textureMeteringMask);
                     }
+                    _cachedMeteringMaskTexture = _textureMeteringMask;
                 }
                 
                 RTHandle meteringMaskHandle = _textureMeteringMaskRTHandle ?? _rendererData.GetWhiteTextureRT();
@@ -469,7 +459,7 @@ namespace Illusion.Rendering.PostProcessing
                 passData.ExposureParams2 = _exposureParams2;
                 
                 // Import exposure curve texture if available with cached RTHandle wrapper
-                if (_exposureCurveRTHandle == null || _exposureCurve == null)
+                if (_exposureCurveRTHandle == null || _cachedExposureCurveTexture != _exposureCurve)
                 {
                     // Release old RTHandle if texture changed
                     if (_exposureCurveRTHandle != null)
@@ -483,6 +473,7 @@ namespace Illusion.Rendering.PostProcessing
                     {
                         _exposureCurveRTHandle = RTHandles.Alloc(_exposureCurve);
                     }
+                    _cachedExposureCurveTexture = _exposureCurve;
                 }
                 
                 RTHandle exposureCurveHandle = _exposureCurveRTHandle ?? _rendererData.GetWhiteTextureRT();
@@ -494,6 +485,7 @@ namespace Illusion.Rendering.PostProcessing
                 passData.AdaptationParams = _adaptationParams;
                 passData.HistogramUsesCurve = _histogramUsesCurve;
                 passData.HistogramOutputDebugData = _histogramOutputDebugData;
+                passData.EmptyHistogram = _emptyHistogram;
                 
                 passData.HistogramBuffer = _rendererData.HistogramBuffer;
                 passData.CameraWidth = cameraData.camera.pixelWidth;
@@ -512,6 +504,8 @@ namespace Illusion.Rendering.PostProcessing
             RTHandles.Release(_exposureCurveRTHandle);
             _textureMeteringMaskRTHandle = null;
             _exposureCurveRTHandle = null;
+            _cachedMeteringMaskTexture = null;
+            _cachedExposureCurveTexture = null;
         }
     }
 }

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceGlobalIllumination/ScreenSpaceGlobalIlluminationPass.cs
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceGlobalIllumination/ScreenSpaceGlobalIlluminationPass.cs
@@ -75,18 +75,6 @@ namespace Illusion.Rendering
 
         private bool _halfResolution;
 
-        private float _historyResolutionScale0;
-
-        private float _historyResolutionScale1;
-
-        private bool _hasSsgiHistory0State;
-
-        private bool _hasSsgiHistory1State;
-
-        private uint _lastSsgiHistory0FrameCount;
-
-        private uint _lastSsgiHistory1FrameCount;
-
         private readonly GraphicsBuffer _pointDistribution;
 
         private bool _denoiserInitialized;
@@ -851,7 +839,7 @@ namespace Illusion.Rendering
             
             // Get previous frame color pyramid
             var preFrameColorRT = _rendererData.GetPreviousFrameColorRT(frameData, out bool isNewFrame);
-            if (!preFrameColorRT.IsValid())
+            if (preFrameColorRT == null || !preFrameColorRT.IsValid())
                 return;
             bool hasPreviousColor = isNewFrame;
             
@@ -859,7 +847,7 @@ namespace Illusion.Rendering
             
             // Get history depth texture
             var historyDepthRT = _rendererData.GetCurrentFrameRT((int)IllusionFrameHistoryType.Depth);
-            bool hasHistoryDepth = historyDepthRT.IsValid();
+            bool hasHistoryDepth = historyDepthRT != null && historyDepthRT.IsValid();
             Vector4 historySizeAndScale = hasHistoryDepth
                 ? _rendererData.EvaluateRayTracingHistorySizeAndScale(historyDepthRT)
                 : Vector4.one;
@@ -870,7 +858,7 @@ namespace Illusion.Rendering
             var historyDepthTexture = renderGraph.ImportTexture(historyDepthRT);
 
             var historyNormalRT = _rendererData.GetCurrentFrameRT((int)IllusionFrameHistoryType.Normal);
-            bool hasHistoryNormal = historyNormalRT.IsValid();
+            bool hasHistoryNormal = historyNormalRT != null && historyNormalRT.IsValid();
             
             // Get motion vector texture
             var motionVectorTexture = resource.motionVectorColor;
@@ -894,6 +882,8 @@ namespace Illusion.Rendering
             // Execute denoising pipeline if enabled
             if (_needDenoise)
             {
+                ref var ssgiState = ref _rendererData.CurrentSsgiHistoryState;
+
                 // Initialize denoiser if needed (only once)
                 if (!_denoiserInitialized)
                 {
@@ -911,7 +901,7 @@ namespace Illusion.Rendering
                 // Allocate first history buffer
                 float scaleFactor = _halfResolution ? 0.5f : 1.0f;
                 var historyBuffer1 = _rendererData.GetCurrentFrameRT((int)IllusionFrameHistoryType.ScreenSpaceGlobalIllumination);
-                bool history0Reallocated = !Mathf.Approximately(scaleFactor, _historyResolutionScale0) || historyBuffer1 == null;
+                bool history0Reallocated = !Mathf.Approximately(scaleFactor, ssgiState.HistoryResolutionScale0) || historyBuffer1 == null;
                 if (history0Reallocated)
                 {
                     _rendererData.ReleaseHistoryFrameRT((int)IllusionFrameHistoryType.ScreenSpaceGlobalIllumination);
@@ -924,15 +914,15 @@ namespace Illusion.Rendering
                 }
                 var historyTexture1 = renderGraph.ImportTexture(historyBuffer1);
                 float historyValidity0 = EvaluateSignalHistoryValidity(commonHistoryValidity, history0Reallocated,
-                    _hasSsgiHistory0State, _lastSsgiHistory0FrameCount);
+                    ssgiState.HasHistory0State, ssgiState.LastHistory0FrameCount);
                 
                 float resolutionMultiplier = _halfResolution ? 0.5f : 1.0f;
                 var temporalOutput = RenderTemporalDenoisePass(renderGraph, cameraData,
                     giTexture, historyTexture1, depthPyramidTexture, validationTexture,
                     motionVectorTexture, exposureTexture, prevExposureTexture, resolutionMultiplier, historyValidity0);
-                _hasSsgiHistory0State = true;
-                _lastSsgiHistory0FrameCount = _rendererData.FrameCount;
-                _historyResolutionScale0 = scaleFactor;
+                ssgiState.HasHistory0State = true;
+                ssgiState.LastHistory0FrameCount = _rendererData.FrameCount;
+                ssgiState.HistoryResolutionScale0 = scaleFactor;
                 
                 // First spatial denoise pass
                 bool halfResFilter = volume.halfResolutionDenoiser.value;
@@ -946,7 +936,7 @@ namespace Illusion.Rendering
                 if (volume.secondDenoiserPass.value)
                 {
                     var historyBuffer2 = _rendererData.GetCurrentFrameRT((int)IllusionFrameHistoryType.ScreenSpaceGlobalIllumination2);
-                    bool history1Reallocated = !Mathf.Approximately(scaleFactor, _historyResolutionScale1) || historyBuffer2 == null;
+                    bool history1Reallocated = !Mathf.Approximately(scaleFactor, ssgiState.HistoryResolutionScale1) || historyBuffer2 == null;
                     if (history1Reallocated)
                     {
                         _rendererData.ReleaseHistoryFrameRT((int)IllusionFrameHistoryType.ScreenSpaceGlobalIllumination2);
@@ -959,14 +949,14 @@ namespace Illusion.Rendering
                     }
                     var historyTexture2 = renderGraph.ImportTexture(historyBuffer2);
                     float historyValidity1 = EvaluateSignalHistoryValidity(commonHistoryValidity, history1Reallocated,
-                        _hasSsgiHistory1State, _lastSsgiHistory1FrameCount);
+                        ssgiState.HasHistory1State, ssgiState.LastHistory1FrameCount);
                     
                     temporalOutput = RenderTemporalDenoisePass(renderGraph, cameraData,
                         giTexture, historyTexture2, depthPyramidTexture, validationTexture,
                         motionVectorTexture, exposureTexture, prevExposureTexture, resolutionMultiplier, historyValidity1);
-                    _hasSsgiHistory1State = true;
-                    _lastSsgiHistory1FrameCount = _rendererData.FrameCount;
-                    _historyResolutionScale1 = scaleFactor;
+                    ssgiState.HasHistory1State = true;
+                    ssgiState.LastHistory1FrameCount = _rendererData.FrameCount;
+                    ssgiState.HistoryResolutionScale1 = scaleFactor;
                     
                     spatialOutput = RenderSpatialDenoisePass(renderGraph, cameraData,
                         temporalOutput, depthPyramidTexture, normalTexture,

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/ScreenSpaceReflectionPass.cs
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/ScreenSpaceReflectionPass.cs
@@ -63,11 +63,7 @@ namespace Illusion.Rendering
 
         private bool _needAccumulate; // usePBRAlgo
 
-        private float _screenSpaceAccumulationResolutionScale;
-        
         private bool _previousAccumNeedClear;
-
-        private ScreenSpaceReflectionAlgorithm _currentSSRAlgorithm;
 
         // PARAMETERS DECLARATION GUIDELINES:
         // All data is aligned on Vector4 size, arrays elements included.
@@ -139,8 +135,12 @@ namespace Illusion.Rendering
             _needAccumulate = _reprojectInCS && renderingData.cameraData.cameraType == CameraType.Game
                                              && volume.usedAlgorithm.value == ScreenSpaceReflectionAlgorithm.PBRAccumulation;
             
-            _previousAccumNeedClear = _needAccumulate && (_currentSSRAlgorithm == ScreenSpaceReflectionAlgorithm.Approximation || _rendererData.IsFirstFrame || _rendererData.ResetPostProcessingHistory);
-            _currentSSRAlgorithm = volume.usedAlgorithm.value; // Store for next frame comparison
+            ref var ssrState = ref _rendererData.CurrentScreenSpaceReflectionHistoryState;
+            _previousAccumNeedClear = _needAccumulate
+                                      && (ssrState.CurrentAlgorithm == ScreenSpaceReflectionAlgorithm.Approximation
+                                          || _rendererData.IsFirstFrame
+                                          || _rendererData.ResetPostProcessingHistory);
+            ssrState.CurrentAlgorithm = volume.usedAlgorithm.value; // Store for next frame comparison
 
             // ================================ Allocation ================================ //
             _targetDescriptor = renderingData.cameraData.cameraTargetDescriptor;
@@ -243,14 +243,16 @@ namespace Illusion.Rendering
 
         private void AllocateScreenSpaceAccumulationHistoryBuffer(float scaleFactor)
         {
-            if (scaleFactor != _screenSpaceAccumulationResolutionScale || _rendererData.GetCurrentFrameRT((int)IllusionFrameHistoryType.ScreenSpaceReflectionAccumulation) == null)
+            ref var ssrState = ref _rendererData.CurrentScreenSpaceReflectionHistoryState;
+            if (!Mathf.Approximately(scaleFactor, ssrState.AccumulationResolutionScale)
+                || _rendererData.GetCurrentFrameRT((int)IllusionFrameHistoryType.ScreenSpaceReflectionAccumulation) == null)
             {
                 _rendererData.ReleaseHistoryFrameRT((int)IllusionFrameHistoryType.ScreenSpaceReflectionAccumulation);
 
                 var ssrAlloc = new IllusionRendererData.CustomHistoryAllocator(new Vector2(scaleFactor, scaleFactor), GraphicsFormat.R16G16B16A16_SFloat, "SSR_Accum Packed history");
                 _rendererData.AllocHistoryFrameRT((int)IllusionFrameHistoryType.ScreenSpaceReflectionAccumulation, ssrAlloc.Allocator, 2);
 
-                _screenSpaceAccumulationResolutionScale = scaleFactor;
+                ssrState.AccumulationResolutionScale = scaleFactor;
             }
         }
 
@@ -268,7 +270,7 @@ namespace Illusion.Rendering
             // The first color pyramid of the frame is generated after the SSR transparent, so we have no choice but to use the previous
             // frame color pyramid (that includes transparents from the previous frame).
             var preFrameColorRT = _rendererData.GetPreviousFrameColorRT(frameData, out _);
-            if (preFrameColorRT == null)
+            if (preFrameColorRT == null || !preFrameColorRT.IsValid())
             {
                 return false;
             }

--- a/Runtime/RenderPipeline/Shadows/ScreenSpaceShadows/ScreenSpaceShadowTemporalPass.cs
+++ b/Runtime/RenderPipeline/Shadows/ScreenSpaceShadows/ScreenSpaceShadowTemporalPass.cs
@@ -21,10 +21,6 @@ namespace Illusion.Rendering.Shadows
         private readonly ProfilingSampler _temporalSampler = new("Screen Space Shadow Temporal");
         private readonly ProfilingSampler _spatialSampler = new("Screen Space Shadow Spatial");
 
-        private bool _hasDirectionalHistoryState;
-        private Vector3 _lastMainLightDirection;
-        private uint _lastHistoryFrameCount;
-
         private class TemporalPassData
         {
             public ComputeShader TemporalFilterCS;
@@ -303,29 +299,31 @@ namespace Illusion.Rendering.Shadows
 
         private float EvaluateHistoryValidity(UniversalLightData lightData)
         {
+            ref var shadowState = ref _rendererData.CurrentScreenSpaceShadowTemporalState;
             float historyValidity = 1.0f;
 
             int mainLightIndex = lightData.mainLightIndex;
             if (mainLightIndex < 0 || mainLightIndex >= lightData.visibleLights.Length || lightData.visibleLights[mainLightIndex].light == null)
             {
-                _hasDirectionalHistoryState = false;
+                shadowState.HasDirectionalHistoryState = false;
                 return 0.0f;
             }
 
             Vector3 currentMainLightDirection = lightData.visibleLights[mainLightIndex].light.transform.forward;
-            bool lightDirectionChanged = !_hasDirectionalHistoryState
-                                         || (currentMainLightDirection - _lastMainLightDirection).sqrMagnitude > 1e-6f;
-            bool nonConsecutiveFrame = !_hasDirectionalHistoryState || (_lastHistoryFrameCount + 1) != _rendererData.FrameCount;
-            bool invalidByFrame = _rendererData.IsFirstFrame || nonConsecutiveFrame;
+            bool lightDirectionChanged = !shadowState.HasDirectionalHistoryState
+                                         || (currentMainLightDirection - shadowState.LastMainLightDirection).sqrMagnitude > 1e-6f;
+            bool nonConsecutiveFrame = !shadowState.HasDirectionalHistoryState
+                                       || (shadowState.LastHistoryFrameCount + 1) != _rendererData.FrameCount;
+            bool invalidByFrame = _rendererData.IsFirstFrame || _rendererData.ResetPostProcessingHistory || nonConsecutiveFrame;
 
             if (lightDirectionChanged || invalidByFrame)
             {
                 historyValidity = 0.0f;
             }
 
-            _lastMainLightDirection = currentMainLightDirection;
-            _lastHistoryFrameCount = _rendererData.FrameCount;
-            _hasDirectionalHistoryState = true;
+            shadowState.LastMainLightDirection = currentMainLightDirection;
+            shadowState.LastHistoryFrameCount = _rendererData.FrameCount;
+            shadowState.HasDirectionalHistoryState = true;
             return historyValidity;
         }
 

--- a/ShaderLibrary/LightingData.hlsl
+++ b/ShaderLibrary/LightingData.hlsl
@@ -91,7 +91,7 @@ half4 CalculateFinalColor(LightingData lightingData, half3 albedo, half alpha, f
 #else
     half fogFactor = fogCoord;
 #endif
-    half3 lightingColor = CalculateLightingColor(lightingData, albedo);
+    half3 lightingColor = CalculateLightingColor(lightingData, albedo) * GetCurrentExposureMultiplier();
     half3 finalColor = MixFog(lightingColor, fogFactor);
 
     return half4(finalColor, alpha);

--- a/ShaderLibrary/ShaderVariables.hlsl
+++ b/ShaderLibrary/ShaderVariables.hlsl
@@ -28,7 +28,7 @@ CBUFFER_END
 #define G_MATRIX_I_VP    _GlobalInvViewProjMatrix
 #define G_MATRIX_V       _GlobalViewMatrix
 
-// Exposure texture - 1x1 RG16F (r: exposure mult, g: exposure EV100)
+// Exposure texture - 1x1 RGFloat (r: exposure mult, g: exposure EV100)
 TEXTURE2D(_ExposureTexture);
 TEXTURE2D(_PrevExposureTexture);
 
@@ -67,7 +67,7 @@ float2 ClampAndScaleUVForPoint(float2 UV)
 
 #define GetCurrentExposureMultiplier IllusionGetCurrentExposureMultiplier
 
-#define GetPreviousExposureMultiplier IllusionGetCurrentExposureMultiplier
+#define GetPreviousExposureMultiplier IllusionGetPreviousExposureMultiplier
 
 float IllusionGetCurrentExposureMultiplier()
 {


### PR DESCRIPTION
## Summary

This PR manually ports the valid parts of the closed PR #28 with an HDRP-aligned approach for multi-camera history and exposure handling.

The main change is moving cross-frame rendering state from renderer-wide globals into lightweight per-camera state, closer to HDRP's `HDCamera` model. This prevents Game View, Scene View, and other cameras from sharing temporal history, exposure history, frame counters, and accumulation validity.

PS5 shim rename/include changes from the original PR are intentionally not included.

## Changes

- Added lightweight per-camera render state in `IllusionRendererData`.
  - Per-camera `BufferedRTHandleSystem`
  - Per-camera frame count and first-frame/reset flags
  - Per-camera TAA frame index and previous view-projection state
  - Per-camera color pyramid mip count
  - Per-camera exposure history textures
  - Per-camera SSGI, screen-space shadow, and SSR temporal validity state

- Updated history RT APIs to use the current camera state.
  - History resources are now isolated per camera.
  - Stale camera states are cleaned up by last-used frame instead of relying on camera active state.

- Aligned exposure handling with HDRP behavior.
  - Initializes the neutral exposure texture.
  - Runs fixed exposure during setup/global binding so the main render sees the current fixed exposure immediately.
  - Keeps histogram exposure writing the next-frame exposure history at the end of the exposure pass.
  - Keeps histogram buffers renderer-level single-frame workspaces, while moving buffer clears onto the GPU timeline.
  - Adds a Scene View fixed-exposure fallback as a lightweight alternative to HDRP scene view exposure settings.

- Moved temporal accumulation validity to per-camera state.
  - SSGI temporal history validity
  - PCSS screen-space shadow temporal validity
  - SSR accumulation algorithm/resolution state

- Fixed shader exposure bugs.
  - `GetPreviousExposureMultiplier` now samples previous exposure instead of current exposure.
  - Final lighting color is pre-exposed with the current exposure multiplier.

## Why

Previously, several cross-frame values were stored globally on the renderer. With multiple cameras, this could cause temporal history and exposure data to leak between cameras, especially when Game View and Scene View were both active.

This PR keeps the architecture lightweight, without introducing a full `IllusionCamera` refactor, while matching HDRP's core ownership model: persistent history belongs to the camera, while temporary histogram buffers remain pipeline-level working resources.