### PR TITLE
Fix transparent post-depth handling under URP depth priming

### DIFF
--- a/Editor/RenderPipeline/TransparentOverdrawStencilStateDataDrawer.cs
+++ b/Editor/RenderPipeline/TransparentOverdrawStencilStateDataDrawer.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
 using UnityEditor;
-using UnityEditor.Rendering.Universal;
 using UnityEngine;
 
 namespace Illusion.Rendering.Editor
@@ -14,7 +12,7 @@ namespace Illusion.Rendering.Editor
                 "For each pixel, the Compare function compares this value with the value in the Stencil buffer. The function writes this value to the buffer if the Pass property is set to Replace.");
 
             public static readonly GUIContent StencilReadMask = EditorGUIUtility.TrTextContent("Read Mask",
-                "For each pixel, the Compare function use this mask to compare the value with the value in the Stencil buffer.");
+                "For each pixel, the Compare function uses this mask to compare the value with the value in the Stencil buffer.");
 
             public static readonly GUIContent StencilFunction = EditorGUIUtility.TrTextContent("Compare Function",
                 "For each pixel, Unity uses this function to compare the value in the Value property with the value in the Stencil buffer.");
@@ -29,82 +27,67 @@ namespace Illusion.Rendering.Editor
                 EditorGUIUtility.TrTextContent("Z Fail", "What happens to the stencil value when failing Z testing.");
         }
 
-        //Stencil rendering
         private const int StencilBits = 4;
         private const int MinStencilValue = 0;
         private const int MaxStencilValue = (1 << StencilBits) - 1;
 
-        //Stencil props
-        private SerializedProperty _overrideStencil;
-        private SerializedProperty _stencilIndex;
-        private SerializedProperty _stencilReadMask;
-        private SerializedProperty _stencilFunction;
-        private SerializedProperty _stencilPass;
-        private SerializedProperty _stencilFail;
-        private SerializedProperty _stencilZFail;
-        private readonly List<SerializedObject> _properties = new();
-
-        private void Init(SerializedProperty property)
-        {
-            //Stencil
-            _overrideStencil = property.FindPropertyRelative("overrideStencilState");
-            _stencilIndex = property.FindPropertyRelative("stencilReference");
-            _stencilReadMask = property.FindPropertyRelative("stencilReadMask");
-            _stencilFunction = property.FindPropertyRelative("stencilCompareFunction");
-            _stencilPass = property.FindPropertyRelative("passOperation");
-            _stencilFail = property.FindPropertyRelative("failOperation");
-            _stencilZFail = property.FindPropertyRelative("zFailOperation");
-
-            _properties.Add(property.serializedObject);
-        }
+        private static float LineSpace => EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
 
         public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
         {
-            if (!_properties.Contains(property.serializedObject))
-                Init(property);
+            var overrideStencil = property.FindPropertyRelative("overrideStencilState");
+            var stencilIndex = property.FindPropertyRelative("stencilReference");
+            var stencilReadMask = property.FindPropertyRelative("stencilReadMask");
+            var stencilFunction = property.FindPropertyRelative("stencilCompareFunction");
+            var stencilPass = property.FindPropertyRelative("passOperation");
+            var stencilFail = property.FindPropertyRelative("failOperation");
+            var stencilZFail = property.FindPropertyRelative("zFailOperation");
 
-            rect.height = EditorGUIUtility.singleLineHeight;
-
-            EditorGUI.PropertyField(rect, _overrideStencil, label);
-            if (_overrideStencil.boolValue)
+            using (new EditorGUI.PropertyScope(rect, label, property))
             {
+                rect.height = EditorGUIUtility.singleLineHeight;
+
+                EditorGUI.PropertyField(rect, overrideStencil, label);
+                if (!overrideStencil.boolValue)
+                    return;
+
                 EditorGUI.indentLevel++;
-                rect.y += EditorUtils.Styles.defaultLineSpace;
-                //Stencil value
-                EditorGUI.BeginChangeCheck();
-                var stencilVal = _stencilIndex.intValue;
-                stencilVal = EditorGUI.IntSlider(rect, Styles.StencilValue, stencilVal, MinStencilValue, MaxStencilValue);
-                if (EditorGUI.EndChangeCheck())
-                    _stencilIndex.intValue = stencilVal;
-                rect.y += EditorUtils.Styles.defaultLineSpace;
-                stencilVal = _stencilReadMask.intValue;
-                stencilVal = EditorGUI.IntSlider(rect, Styles.StencilReadMask, stencilVal, MinStencilValue, MaxStencilValue);
-                if (EditorGUI.EndChangeCheck())
-                    _stencilReadMask.intValue = stencilVal;
-                rect.y += EditorUtils.Styles.defaultLineSpace;
-                //Stencil compare options
-                EditorGUI.PropertyField(rect, _stencilFunction, Styles.StencilFunction);
-                rect.y += EditorUtils.Styles.defaultLineSpace;
+                rect.y += LineSpace;
+
+                DrawIntSlider(rect, stencilIndex, Styles.StencilValue);
+                rect.y += LineSpace;
+
+                DrawIntSlider(rect, stencilReadMask, Styles.StencilReadMask);
+                rect.y += LineSpace;
+
+                EditorGUI.PropertyField(rect, stencilFunction, Styles.StencilFunction);
+                rect.y += LineSpace;
+
                 EditorGUI.indentLevel++;
-                EditorGUI.PropertyField(rect, _stencilPass, Styles.StencilPass);
-                rect.y += EditorUtils.Styles.defaultLineSpace;
-                EditorGUI.PropertyField(rect, _stencilFail, Styles.StencilFail);
-                rect.y += EditorUtils.Styles.defaultLineSpace;
+                EditorGUI.PropertyField(rect, stencilPass, Styles.StencilPass);
+                rect.y += LineSpace;
+
+                EditorGUI.PropertyField(rect, stencilFail, Styles.StencilFail);
+                rect.y += LineSpace;
                 EditorGUI.indentLevel--;
-                //Stencil compare options
-                EditorGUI.PropertyField(rect, _stencilZFail, Styles.StencilZFail);
+
+                EditorGUI.PropertyField(rect, stencilZFail, Styles.StencilZFail);
                 EditorGUI.indentLevel--;
             }
         }
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            if (_properties.Contains(property.serializedObject))
-            {
-                if (_overrideStencil != null && _overrideStencil.boolValue)
-                    return EditorUtils.Styles.defaultLineSpace * 7;
-            }
-            return EditorUtils.Styles.defaultLineSpace * 1;
+            var overrideStencil = property.FindPropertyRelative("overrideStencilState");
+            return overrideStencil != null && overrideStencil.boolValue ? LineSpace * 7 : LineSpace;
+        }
+
+        private static void DrawIntSlider(Rect rect, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginChangeCheck();
+            int value = EditorGUI.IntSlider(rect, label, property.intValue, MinStencilValue, MaxStencilValue);
+            if (EditorGUI.EndChangeCheck())
+                property.intValue = value;
         }
     }
 }

--- a/Runtime/RenderPipeline/IllusionRendererData.cs
+++ b/Runtime/RenderPipeline/IllusionRendererData.cs
@@ -88,6 +88,19 @@ namespace Illusion.Rendering
             ShadingRateImage = TextureHandle.nullHandle;
         }
     }   
+
+    public class TransparentDepthData : ContextItem
+    {
+        public TextureHandle PreDepthTexture;
+
+        public TextureHandle PostDepthTexture;
+
+        public override void Reset()
+        {
+            PreDepthTexture = TextureHandle.nullHandle;
+            PostDepthTexture = TextureHandle.nullHandle;
+        }
+    }
     
     /// <summary>
     /// IllusionRP renderer shared data
@@ -146,11 +159,6 @@ namespace Illusion.Rendering
 
         // Not support VR yet
         public const int MaxViewCount = 1;
-
-        /// <summary>
-        /// Depth texture after transparent depth normal but before transparent depth only.
-        /// </summary>
-        public RTHandle CameraPreDepthTextureRT;
 
         public RTHandle ContactShadowsRT;
 
@@ -392,13 +400,10 @@ namespace Illusion.Rendering
             PreIntegratedFGD = new PreIntegratedFGD(renderPipelineResources);
             DepthPyramidMipLevelOffsetsBuffer = new ComputeBuffer(15, sizeof(int) * 2);
             MipGenerator = new MipGenerator(this);
-            // Setup a default exposure textures and clear it to neutral values so that the exposure
-            // multiplier is 1 and thus has no effect
-            // Beware that 0 in EV100 maps to a multiplier of 0.833 so the EV100 value in this
-            // neutral exposure texture isn't 0
+            // Do not clear this texture in the renderer feature constructor. A constructor-time
+            // Graphics.Blit can run in scenes without cameras and disturb Overlay Canvas sizing.
             _emptyExposureTexture = RTHandles.Alloc(1, 1, colorFormat: ExposureFormat,
                 enableRandomWrite: true, name: "Empty EV100 Exposure");
-            SetExposureTextureToEmpty(_emptyExposureTexture);
 
             _debugExposureData = RTHandles.Alloc(1, 1, colorFormat: ExposureFormat,
                 enableRandomWrite: true, name: "Debug Exposure Info");
@@ -442,7 +447,6 @@ namespace Illusion.Rendering
             _cameraStates.Clear();
             _staleCameraStateKeys.Clear();
             _currentCameraState = null;
-            CameraPreDepthTextureRT?.Release();
             CameraPreviousColorTextureRT?.Release();
             DepthPyramidMipLevelOffsetsBuffer?.Release();
             ScreenSpaceShadowsRT?.Release();

--- a/Runtime/RenderPipeline/IllusionRendererFeature.cs
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.cs
@@ -288,7 +288,7 @@ namespace Illusion.Rendering
             _weightedBlendedOitPass = new WeightedBlendedOITPass(oitFilterLayer);
             _transparentOverdrawPass = TransparentOverdrawPass.Create(oitOverrideStencil);
             _transparentDepthOnlyPass = new TransparentDepthOnlyPostPass(_rendererData);
-            _transparentCopyPreDepthPass = new TransparentCopyPreDepthPass(_rendererData);
+            _transparentCopyPreDepthPass = new TransparentCopyPreDepthPass();
             _transparentCopyPostDepthPass = new TransparentCopyPostDepthPass();
 
             _screenSpaceReflectionPass = new ScreenSpaceReflectionPass(_rendererData);

--- a/Runtime/RenderPipeline/Shadows/ScreenSpaceShadows/ScreenSpaceShadowsPass.cs
+++ b/Runtime/RenderPipeline/Shadows/ScreenSpaceShadows/ScreenSpaceShadowsPass.cs
@@ -133,10 +133,11 @@ namespace Illusion.Rendering.Shadows
             TextureHandle screenSpaceShadowsTexture = renderGraph.ImportTexture(_rendererData.ScreenSpaceShadowsRT);
             
             TextureHandle preDepthTexture = resource.cameraDepthTexture;
-            var preDepthRT = _rendererData.CameraPreDepthTextureRT;
-            if (preDepthRT.IsValid())
+            if (frameData.Contains<TransparentDepthData>())
             {
-                preDepthTexture = renderGraph.ImportTexture(preDepthRT);
+                var transparentDepthData = frameData.Get<TransparentDepthData>();
+                if (transparentDepthData.PreDepthTexture.IsValid())
+                    preDepthTexture = transparentDepthData.PreDepthTexture;
             }
 
             // PCSS Penumbra Pass - Use UnsafePass for multiple render target switching

--- a/Runtime/RenderPipeline/SubsurfaceScattering/SubsurfaceScatteringPass.cs
+++ b/Runtime/RenderPipeline/SubsurfaceScattering/SubsurfaceScatteringPass.cs
@@ -154,6 +154,8 @@ namespace Illusion.Rendering
         {
             internal RendererListHandle RendererListHdl;
             internal Color[] BackGroundColors;
+            internal TextureHandle SceneDepthTexture;
+            internal bool BindSceneDepthTexture;
         }
 
         private class ScatteringComputePassData
@@ -163,6 +165,7 @@ namespace Illusion.Rendering
             internal TextureHandle DiffuseTexture;
             internal TextureHandle AlbedoTexture;
             internal TextureHandle LightingTexture;
+            internal TextureHandle SceneDepthTexture;
             internal int SampleBudget;
             internal int Width;
             internal int Height;
@@ -174,6 +177,7 @@ namespace Illusion.Rendering
             internal TextureHandle DiffuseTexture;
             internal TextureHandle AlbedoTexture;
             internal TextureHandle LightingTexture;
+            internal TextureHandle SceneDepthTexture;
         }
 
         private class SetGlobalPassData
@@ -187,19 +191,24 @@ namespace Illusion.Rendering
         }
 
         private void RenderSplitLighting(RenderGraph renderGraph, TextureHandle diffuseHandle, TextureHandle albedoHandle, 
-            TextureHandle depthHandle, ContextContainer frameData)
+            TextureHandle depthAttachment, TextureHandle depthTexture, ContextContainer frameData)
         {
             UniversalRenderingData renderingData = frameData.Get<UniversalRenderingData>();
             UniversalCameraData cameraData = frameData.Get<UniversalCameraData>();
             UniversalLightData lightData = frameData.Get<UniversalLightData>();
+            bool bindSceneDepthTexture = depthTexture.IsValid() && !depthTexture.Equals(depthAttachment);
             using (var builder = renderGraph.AddRasterRenderPass<SplitLightingPassData>("SSS Split Lighting", out var passData))
             {
                 // Setup MRT: diffuse (attachment 0) + albedo (attachment 1)
                 builder.SetRenderAttachment(diffuseHandle, 0);
                 builder.SetRenderAttachment(albedoHandle, 1);
-                builder.SetRenderAttachmentDepth(depthHandle);
+                builder.SetRenderAttachmentDepth(depthAttachment, AccessFlags.ReadWrite);
+                if (bindSceneDepthTexture)
+                    builder.UseTexture(depthTexture);
 
                 passData.BackGroundColors = _backGroundColors;
+                passData.SceneDepthTexture = depthTexture;
+                passData.BindSceneDepthTexture = bindSceneDepthTexture;
 
                 // Create renderer list with SubsurfaceDiffuse shader tag
                 var drawingSettings = CreateDrawingSettings(SubsurfaceDiffuseShaderTagId, renderingData, cameraData, lightData, SortingCriteria.None);
@@ -208,9 +217,13 @@ namespace Illusion.Rendering
                 builder.UseRendererList(passData.RendererListHdl);
 
                 builder.AllowPassCulling(false);
+                builder.AllowGlobalStateModification(true);
 
                 builder.SetRenderFunc(static (SplitLightingPassData data, RasterGraphContext context) =>
                 {
+                    if (data.BindSceneDepthTexture)
+                        context.cmd.SetGlobalTexture(IllusionShaderProperties._CameraDepthTexture, data.SceneDepthTexture);
+
                     // Clear render targets
                     context.cmd.ClearRenderTarget(RTClearFlags.Color0 | RTClearFlags.Color1, data.BackGroundColors, 1, 0);
                     
@@ -221,7 +234,7 @@ namespace Illusion.Rendering
         }
 
         private void RenderScatteringCompute(RenderGraph renderGraph, TextureHandle diffuseHandle, 
-            TextureHandle albedoHandle, TextureHandle lightingHandle)
+            TextureHandle albedoHandle, TextureHandle lightingHandle, TextureHandle sceneDepthTexture, TextureHandle restoreDepthTexture)
         {
             using (var builder = renderGraph.AddComputePass<ScatteringComputePassData>("SSS Scattering (Compute)", out var passData))
             {
@@ -233,16 +246,23 @@ namespace Illusion.Rendering
                 passData.AlbedoTexture = albedoHandle;
                 builder.UseTexture(lightingHandle, AccessFlags.Write);
                 passData.LightingTexture = lightingHandle;
+                builder.UseTexture(sceneDepthTexture);
+                passData.SceneDepthTexture = sceneDepthTexture;
+                builder.UseTexture(restoreDepthTexture);
                 passData.SampleBudget = _sampleBudget;
                 passData.Width = _width;
                 passData.Height = _height;
 
                 builder.AllowPassCulling(false);
+                builder.AllowGlobalStateModification(true);
 
                 builder.SetGlobalTextureAfterPass(lightingHandle, ShaderIDs._SubsurfaceLighting);
+                builder.SetGlobalTextureAfterPass(restoreDepthTexture, IllusionShaderProperties._CameraDepthTexture);
                 
                 builder.SetRenderFunc(static (ScatteringComputePassData data, ComputeGraphContext context) =>
                 {
+                    context.cmd.SetGlobalTexture(IllusionShaderProperties._CameraDepthTexture, data.SceneDepthTexture);
+
                     // Set compute shader parameters
                     context.cmd.SetComputeIntParam(data.ComputeShader, ShaderIDs._SssSampleBudget, data.SampleBudget);
                     context.cmd.SetComputeTextureParam(data.ComputeShader, data.SubsurfaceScatteringKernel, 
@@ -251,6 +271,8 @@ namespace Illusion.Rendering
                         ShaderIDs._SubsurfaceAlbedo, data.AlbedoTexture);
                     context.cmd.SetComputeTextureParam(data.ComputeShader, data.SubsurfaceScatteringKernel, 
                         ShaderIDs._SubsurfaceLighting, data.LightingTexture);
+                    context.cmd.SetComputeTextureParam(data.ComputeShader, data.SubsurfaceScatteringKernel,
+                        IllusionShaderProperties._CameraDepthTexture, data.SceneDepthTexture);
 
                     var numTilesX = (data.Width + 15) / 16;
                     var numTilesY = (data.Height + 15) / 16;
@@ -264,7 +286,7 @@ namespace Illusion.Rendering
         }
 
         private void RenderScatteringRaster(RenderGraph renderGraph, TextureHandle diffuseHandle, 
-            TextureHandle albedoHandle, TextureHandle lightingHandle)
+            TextureHandle albedoHandle, TextureHandle lightingHandle, TextureHandle sceneDepthTexture, TextureHandle restoreDepthTexture)
         {
             using (var builder = renderGraph.AddRasterRenderPass<ScatteringRasterPassData>("SSS Scattering (Raster)", out var passData))
             {
@@ -275,13 +297,20 @@ namespace Illusion.Rendering
                 passData.AlbedoTexture = albedoHandle;
                 builder.SetRenderAttachment(lightingHandle, 0);
                 passData.LightingTexture = lightingHandle;
+                builder.UseTexture(sceneDepthTexture);
+                passData.SceneDepthTexture = sceneDepthTexture;
+                builder.UseTexture(restoreDepthTexture);
 
                 builder.AllowPassCulling(false);
+                builder.AllowGlobalStateModification(true);
 
                 builder.SetGlobalTextureAfterPass(lightingHandle, ShaderIDs._SubsurfaceLighting);
+                builder.SetGlobalTextureAfterPass(restoreDepthTexture, IllusionShaderProperties._CameraDepthTexture);
                 
                 builder.SetRenderFunc(static (ScatteringRasterPassData data, RasterGraphContext context) =>
                 {
+                    context.cmd.SetGlobalTexture(IllusionShaderProperties._CameraDepthTexture, data.SceneDepthTexture);
+
                     // Disable native render pass keyword
                     data.ScatteringMaterial.DisableKeyword(IllusionShaderKeywords._ILLUSION_RENDER_PASS_ENABLED);
                     
@@ -330,16 +359,16 @@ namespace Illusion.Rendering
             TextureHandle albedoHandle = renderGraph.ImportTexture(_diffuseRT[1]);
             TextureHandle lightingHandle = renderGraph.ImportTexture(_diffuseRT[2]);
 
-            // Get depth texture
-            TextureHandle depthHandle;
-            var preDepthTexture = _rendererData.CameraPreDepthTextureRT;
-            if (!preDepthTexture.IsValid() || cameraData.cameraType == CameraType.Preview)
+            // Keep sampling on the pre-transparent depth texture, but attach a real depth buffer for raster draws.
+            TextureHandle sceneDepthTexture = resource.cameraDepthTexture;
+            TextureHandle depthAttachmentHandle = frameData.GetDepthWriteTextureHandle();
+            if (cameraData.cameraType != CameraType.Preview && frameData.Contains<TransparentDepthData>())
             {
-                depthHandle = resource.cameraDepthTexture;
-            }
-            else
-            {
-                depthHandle = renderGraph.ImportTexture(preDepthTexture);
+                var transparentDepthData = frameData.Get<TransparentDepthData>();
+                if (transparentDepthData.PreDepthTexture.IsValid())
+                {
+                    sceneDepthTexture = transparentDepthData.PreDepthTexture;
+                }
             }
 
             // Check if SSS is enabled
@@ -364,8 +393,8 @@ namespace Illusion.Rendering
                 setupPassData.Width = _width;
                 setupPassData.Height = _height;
 
-                builder.AllowGlobalStateModification(true);
                 builder.AllowPassCulling(false);
+                builder.AllowGlobalStateModification(true);
 
                 builder.SetRenderFunc((SetGlobalPassData data, ComputeGraphContext context) =>
                 {
@@ -382,16 +411,16 @@ namespace Illusion.Rendering
             }
 
             // Pass 2: Split lighting rendering (RasterPass with MRT)
-            RenderSplitLighting(renderGraph, diffuseHandle, albedoHandle, depthHandle, frameData);
+            RenderSplitLighting(renderGraph, diffuseHandle, albedoHandle, depthAttachmentHandle, sceneDepthTexture, frameData);
 
             // Pass 3: Subsurface scattering (Compute or Raster)
             if (_scatteringInCS)
             {
-                RenderScatteringCompute(renderGraph, diffuseHandle, albedoHandle, lightingHandle);
+                RenderScatteringCompute(renderGraph, diffuseHandle, albedoHandle, lightingHandle, sceneDepthTexture, resource.cameraDepthTexture);
             }
             else
             {
-                RenderScatteringRaster(renderGraph, diffuseHandle, albedoHandle, lightingHandle);
+                RenderScatteringRaster(renderGraph, diffuseHandle, albedoHandle, lightingHandle, sceneDepthTexture, resource.cameraDepthTexture);
             }
         }
 

--- a/Runtime/RenderPipeline/Transparency/TransparentCopyPreDepthPass.cs
+++ b/Runtime/RenderPipeline/Transparency/TransparentCopyPreDepthPass.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using UnityEngine;
-using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.RenderGraphModule;
 using UnityEngine.Rendering.Universal;
@@ -13,15 +12,10 @@ namespace Illusion.Rendering
     /// </summary>
     public class TransparentCopyPreDepthPass :  ScriptableRenderPass, IDisposable
     {
-        private readonly Material _copyDepthMaterial;
-
-        private readonly IllusionRendererData _rendererData;
-
         private readonly CopyDepthPass _copyDepthPass;
 
-        public TransparentCopyPreDepthPass(IllusionRendererData rendererData)
+        public TransparentCopyPreDepthPass()
         {
-            _rendererData = rendererData;
             Shader copyDephPS = null;
             if (GraphicsSettings.TryGetRenderPipelineSettings<UniversalRendererResources>(out var universalRendererShaders))
             {
@@ -30,37 +24,48 @@ namespace Illusion.Rendering
             profilingSampler = new ProfilingSampler("CopyPreDepth");
             renderPassEvent = IllusionRenderPassEvent.TransparentCopyPreDepthPass;
             _copyDepthPass = new CopyDepthPass(renderPassEvent, copyDephPS, true, false, RenderingUtils.MultisampleDepthResolveSupported())
-                {
-                    profilingSampler = profilingSampler
-                };
+            {
+                profilingSampler = profilingSampler
+            };
             ConfigureInput(ScriptableRenderPassInput.Depth);
         }
-        
+         
         public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
         {
             var resource = frameData.Get<UniversalResourceData>();
             var cameraData = frameData.Get<UniversalCameraData>();
             var universalRenderer = (UniversalRenderer)cameraData.renderer;
             TextureHandle source = resource.cameraDepthTexture;
-            
-            // Allocate pre-depth texture
-            var depthDescriptor = cameraData.cameraTargetDescriptor;
-            depthDescriptor.graphicsFormat = GraphicsFormat.None;
-            depthDescriptor.depthStencilFormat = universalRenderer.cameraDepthTextureFormat;
-            depthDescriptor.msaaSamples = 1; // Depth-Only pass don't use MSAA
+            if (!source.IsValid())
+                return;
+             
+            var transparentDepthData = frameData.GetOrCreate<TransparentDepthData>();
+            transparentDepthData.PreDepthTexture = source;
 
-            RenderingUtils.ReAllocateHandleIfNeeded(ref _rendererData.CameraPreDepthTextureRT, depthDescriptor, 
-                wrapMode: TextureWrapMode.Clamp, name: "_CameraPreDepthTexture");
-            
-            TextureHandle destination = renderGraph.ImportTexture(_rendererData.CameraPreDepthTextureRT);
+            var postDepthDesc = renderGraph.GetTextureDesc(source);
+            postDepthDesc.name = "_CameraTransparentPostDepthTexture";
+            postDepthDesc.format = universalRenderer.cameraDepthTextureFormat;
+            postDepthDesc.msaaSamples = MSAASamples.None;
+            postDepthDesc.bindTextureMS = false;
+            postDepthDesc.useMipMap = false;
+            postDepthDesc.autoGenerateMips = false;
+            postDepthDesc.enableRandomWrite = false;
+            postDepthDesc.clearBuffer = true;
+            postDepthDesc.clearColor = Color.clear;
+            postDepthDesc.filterMode = FilterMode.Point;
+            postDepthDesc.wrapMode = TextureWrapMode.Clamp;
+
+            TextureHandle destination = renderGraph.CreateTexture(postDepthDesc);
+            transparentDepthData.PostDepthTexture = destination;
 
             _copyDepthPass.CopyToDepth = true;
-            _copyDepthPass.Render(renderGraph, destination, source, resource, cameraData, bindAsCameraDepth: false, passName: "Copy Pre Depth");
+            _copyDepthPass.Render(renderGraph, destination, source, resource, cameraData,
+                bindAsCameraDepth: false, passName: "Prepare Transparent Post Depth");
         }
 
         public void Dispose()
         {
-            CoreUtils.Destroy(_copyDepthMaterial);
+            _copyDepthPass?.Dispose();
         }
     }
 }

--- a/Runtime/RenderPipeline/Transparency/TransparentDepthOnlyPostPass.cs
+++ b/Runtime/RenderPipeline/Transparency/TransparentDepthOnlyPostPass.cs
@@ -47,7 +47,11 @@ namespace Illusion.Rendering
                 return;
 #endif
 
-            TextureHandle depthTexture = resource.cameraDepthTexture;
+            if (!frameData.Contains<TransparentDepthData>())
+                return;
+
+            var transparentDepthData = frameData.Get<TransparentDepthData>();
+            TextureHandle depthTexture = transparentDepthData.PostDepthTexture;
             if (!depthTexture.IsValid())
                 return;
 
@@ -56,7 +60,7 @@ namespace Illusion.Rendering
             using (var builder = renderGraph.AddRasterRenderPass<PassData>(DepthProfilerTag, out var passData, profilingSampler))
             {
                 builder.SetRenderAttachment(forwardGBufferHandle, 0);
-                builder.SetRenderAttachmentDepth(depthTexture);
+                builder.SetRenderAttachmentDepth(depthTexture, AccessFlags.ReadWrite);
 
                 var drawSettings = UniversalRenderingUtility.CreateDrawingSettings(ShaderTagIds, frameData, cameraData.defaultOpaqueSortFlags);
                 var rendererListParams = new RendererListParams(renderingData.cullResults, drawSettings, _filteringSettings);
@@ -67,12 +71,15 @@ namespace Illusion.Rendering
                 builder.AllowGlobalStateModification(true);
 
                 builder.SetGlobalTextureAfterPass(forwardGBufferHandle, IllusionShaderProperties._ForwardGBuffer);
+                builder.SetGlobalTextureAfterPass(depthTexture, IllusionShaderProperties._CameraDepthTexture);
 
                 builder.SetRenderFunc((PassData data, RasterGraphContext context) =>
                 {
                     context.cmd.DrawRendererList(data.RendererList);
                 });
             }
+
+            resource.cameraDepthTexture = depthTexture;
         }
 
         public void Dispose()


### PR DESCRIPTION
Allocate a frame-local depth-stencil texture for transparent post-depth instead of writing directly to _CameraDepthTexture, which can be R32_SFloat when depth priming is enabled in Unity 6.3.16.

Copy the pre-transparent depth into the new texture using URP's CopyDepthPass, render transparent PostDepthOnly depth/stencil into it, then redirect cameraDepthTexture and _CameraDepthTexture for downstream post-processing.

Also keep SSS and screen-space shadows sampling the original pre-transparent depth, while ensuring raster passes use a real depth attachment format.

Fixes #32 