### PR TITLE
Skip initialization of disabled shadow denoisers

### DIFF
--- a/Runtime/RenderPipeline/IllusionRendererFeature.cs
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.cs
@@ -271,8 +271,14 @@ namespace Illusion.Rendering
 
             _contactShadowsPass = new ContactShadowsPass(_rendererData);
             _screenSpaceShadowsPass = new ScreenSpaceShadowsPass(_rendererData);
-            _screenSpaceShadowTemporalPass = new ScreenSpaceShadowTemporalPass(_rendererData);
-            _diffuseShadowDenoisePass = new DiffuseShadowDenoisePass(_rendererData);
+            if (pcssShadows)
+            {
+                _screenSpaceShadowTemporalPass = new ScreenSpaceShadowTemporalPass(_rendererData);
+            }
+            if (contactShadows)
+            {
+                _diffuseShadowDenoisePass = new DiffuseShadowDenoisePass(_rendererData);
+            }
             _screenSpaceShadowsPostPass = new ScreenSpaceShadowsPostPass();
             _subsurfaceScatteringPass = new SubsurfaceScatteringPass(_rendererData);
             _groundTruthAmbientOcclusionPass = new GroundTruthAmbientOcclusionPass(_rendererData);


### PR DESCRIPTION
## Summary
- create the screen-space shadow temporal pass only when PCSS shadows are enabled
- create the diffuse shadow denoise pass only when contact shadows are enabled
- avoid resolving unsupported compute kernels for shadow features that will never be enqueued

## Test plan
- [x] Opened a Unity 6000.3 project on macOS/Metal with IllusionRP SSGI enabled
- [x] Kept Contact Shadows and PCSS Shadows disabled
- [x] Verified the project renders without `Kernel 'BilateralFilterHSingleDirectional' not found` or repeated `Blitter is already initialized` exceptions