### PR TITLE
Fix rendering issues and update package version to 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to this package will be documented in this file.
 
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix screen-space shadow temporal accumulation artifacts by improving history validation and aligning reprojection behavior with HDRP.
 - Fix skin transmission lighting to preserve the raw light-facing term for backlit evaluation.
 - Fix skin Fresnel F0 storage to preserve RGB values when metallic or color-tinted F0 expressions are used.
+- Fix SSGI half-resolution ray tracing and reprojection coordinate mapping by using the same representative low-resolution pixel mapping as HDRP.
+- Fix color pyramid render target sizing under render scale and dynamic resolution by using the camera target descriptor size.
+- Fix Motion Vectors Debug output under URP RenderGraph by rendering through a temporary debug texture before the final camera-color blit.
+- Fix `_TaaFrameInfo` channel ordering so SSR blue-noise sampling uses the frame count while PCSS and per-object shadow jitter use the TAA frame index.
 
 ## [1.2.3] - 2026-6-6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to this package will be documented in this file.
 

--- a/Runtime/RenderPipeline/ColorPyramidPass.cs
+++ b/Runtime/RenderPipeline/ColorPyramidPass.cs
@@ -82,7 +82,7 @@ namespace Illusion.Rendering
             var colorPyramidRT = _rendererData.GetCurrentFrameRT((int)IllusionFrameHistoryType.ColorBufferMipChain);
             TextureHandle colorPyramidHandle = renderGraph.ImportTexture(colorPyramidRT);
 
-            Vector2Int pyramidSize = new Vector2Int(cameraData.camera.pixelWidth, cameraData.camera.pixelHeight);
+            Vector2Int pyramidSize = new Vector2Int(cameraData.cameraTargetDescriptor.width, cameraData.cameraTargetDescriptor.height);
 
             // Calculate scale and bias for DRS (Dynamic Resolution Scaling)
             bool isHardwareDrsOn = DynamicResolutionHandler.instance.HardwareDynamicResIsEnabled();

--- a/Runtime/RenderPipeline/IllusionRendererData.cs
+++ b/Runtime/RenderPipeline/IllusionRendererData.cs
@@ -592,7 +592,7 @@ namespace Illusion.Rendering
             const int kMaxSampleCount = 8;
             if (++cameraState.TaaFrameIndex >= kMaxSampleCount)
                 cameraState.TaaFrameIndex = 0;
-            _shaderVariablesGlobal.TaaFrameInfo = new Vector4(0, cameraState.TaaFrameIndex, FrameCount, useTAA ? 1 : 0);
+            _shaderVariablesGlobal.TaaFrameInfo = new Vector4(0, FrameCount, cameraState.TaaFrameIndex, useTAA ? 1 : 0);
             _shaderVariablesGlobal.ColorPyramidUvScaleAndLimitPrevFrame
                 = IllusionRenderingUtils.ComputeViewportScaleAndLimit(historyRTSystem.rtHandleProperties.previousViewportSize,
                     historyRTSystem.rtHandleProperties.previousRenderTargetSize);

--- a/Runtime/RenderPipeline/PostProcessing/MotionVectorsDebugPass.cs
+++ b/Runtime/RenderPipeline/PostProcessing/MotionVectorsDebugPass.cs
@@ -1,6 +1,7 @@
 ﻿#if DEVELOPMENT_BUILD || UNITY_EDITOR
 using System;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.RenderGraphModule;
 using UnityEngine.Rendering.Universal;
@@ -14,7 +15,7 @@ namespace Illusion.Rendering
         public MotionVectorsDebugPass(IllusionRendererData rendererData)
         {
             profilingSampler = new ProfilingSampler("Motion Vectors Debug");
-            renderPassEvent = IllusionRenderPassEvent.MotionVectorDebugPass;
+            renderPassEvent = IllusionRenderPassEvent.FullScreenDebugPass;
             ConfigureInput(ScriptableRenderPassInput.Motion);
         }
         
@@ -22,35 +23,67 @@ namespace Illusion.Rendering
         {
             internal Material MotionVectorDebugMaterial;
             internal TextureHandle MotionVectorColor;
-            internal TextureHandle ColorDestination;
+            internal Vector4 DebugParams;
+        }
+
+        private class FinalBlitPassData
+        {
+            internal TextureHandle Source;
         }
 
         public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
         {
             var resources = frameData.Get<UniversalResourceData>();
             var motionVectorFromResources = resources.motionVectorColor;
-            if (!motionVectorFromResources.IsValid()) return;
-
+            TextureHandle colorTargetHandle = resources.cameraColor;
+            var debugOutputDesc = renderGraph.GetTextureDesc(colorTargetHandle);
+            debugOutputDesc.name = "Motion Vectors Debug Output";
+            debugOutputDesc.msaaSamples = MSAASamples.None;
+            debugOutputDesc.depthBufferBits = DepthBits.None;
+            debugOutputDesc.clearBuffer = false;
+            TextureHandle debugOutput = renderGraph.CreateTexture(debugOutputDesc);
             
-            TextureHandle colorTargetHandle = resources.activeColorTexture;
-            
-            using (var builder = renderGraph.AddRasterRenderPass<MotionVectorsDebugPassData>("Motion Vectors Debug", 
+            using (var builder = renderGraph.AddRasterRenderPass<MotionVectorsDebugPassData>("Motion Vectors Debug",
                 out var passData, profilingSampler))
             {
                 passData.MotionVectorDebugMaterial = _motionVectorDebugMaterial.Value;
-                builder.UseTexture(motionVectorFromResources);
-                passData.MotionVectorColor = motionVectorFromResources;
+                passData.DebugParams = new Vector4(
+                    motionVectorFromResources.IsValid() ? 1.0f : 0.0f,
+                    0.0f,
+                    0.0f,
+                    0.0f);
+                if (motionVectorFromResources.IsValid())
+                {
+                    builder.UseTexture(motionVectorFromResources);
+                    passData.MotionVectorColor = motionVectorFromResources;
+                }
                 
-                builder.SetRenderAttachment(colorTargetHandle, 0);
-                passData.ColorDestination = colorTargetHandle;
+                builder.SetRenderAttachment(debugOutput, 0);
                 
                 builder.AllowPassCulling(false);
                 builder.AllowGlobalStateModification(true);
                 
                 builder.SetRenderFunc(static (MotionVectorsDebugPassData data, RasterGraphContext context) =>
                 {
-                    data.MotionVectorDebugMaterial.SetTexture(IllusionShaderProperties._MotionVectorTexture, data.MotionVectorColor);
-                    Blitter.BlitTexture(context.cmd, new Vector4(1, 1, 0, 0), data.MotionVectorDebugMaterial, 0);
+                    if (data.MotionVectorColor.IsValid())
+                        data.MotionVectorDebugMaterial.SetTexture(IllusionShaderProperties._MotionVectorTexture, data.MotionVectorColor);
+                    data.MotionVectorDebugMaterial.SetVector("_DebugMotionVectorsParams", data.DebugParams);
+                    context.cmd.DrawProcedural(Matrix4x4.identity, data.MotionVectorDebugMaterial, 0,
+                        MeshTopology.Triangles, 3, 1);
+                });
+            }
+
+            using (var builder = renderGraph.AddRasterRenderPass<FinalBlitPassData>("Motion Vectors Debug Final Blit",
+                out var passData, profilingSampler))
+            {
+                builder.UseTexture(debugOutput);
+                passData.Source = debugOutput;
+                builder.SetRenderAttachment(colorTargetHandle, 0);
+                builder.AllowPassCulling(false);
+
+                builder.SetRenderFunc(static (FinalBlitPassData data, RasterGraphContext context) =>
+                {
+                    Blitter.BlitTexture(context.cmd, data.Source, new Vector4(1, 1, 0, 0), 0.0f, false);
                 });
             }
         }

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceGlobalIllumination/ScreenSpaceGlobalIlluminationPass.cs
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceGlobalIllumination/ScreenSpaceGlobalIlluminationPass.cs
@@ -91,6 +91,8 @@ namespace Illusion.Rendering
 
             public int RayMarchingFallbackHierarchy;
             public int IndirectDiffuseFrameIndex;
+            public float RayMarchingLowResPercentageInv;
+            public int RayMarchingLowResPadding;
         }
 
         public ScreenSpaceGlobalIlluminationPass(IllusionRendererData rendererData)
@@ -298,6 +300,8 @@ namespace Illusion.Rendering
 
             // Frame index for temporal sampling
             _giVariables.IndirectDiffuseFrameIndex = (int)(_rendererData.FrameCount % 16);
+            _giVariables.RayMarchingLowResPercentageInv = _halfResolution ? 2.0f : 1.0f;
+            _giVariables.RayMarchingLowResPadding = 0;
         }
 
         private static float GetPixelSpreadTangent(float fov, int width, int height)

--- a/Shaders/PostProcessing/DebugMotionVectors.shader
+++ b/Shaders/PostProcessing/DebugMotionVectors.shader
@@ -1,53 +1,66 @@
 ﻿Shader "Hidden/DebugMotionVectors"
 {
+    HLSLINCLUDE
+    #include "Packages/com.kurisu.illusion-render-pipelines/ShaderLibrary/ShaderVariables.hlsl"
+    #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+
+    #pragma vertex Vert
+    #pragma fragment Frag
+
+    TEXTURE2D_X(_MotionVectorTexture);
+    SAMPLER(sampler_MotionVectorTexture);
+
+    float4 _DebugMotionVectorsParams;
+    #define _DebugMotionVectorValid _DebugMotionVectorsParams.x
+
+    struct Attributes
+    {
+        uint vertexID : SV_VertexID;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct Varyings
+    {
+        float4 positionCS : SV_POSITION;
+        float2 texcoord : TEXCOORD0;
+        UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    Varyings Vert(Attributes input)
+    {
+        Varyings output;
+        UNITY_SETUP_INSTANCE_ID(input);
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+        output.positionCS = GetFullScreenTriangleVertexPosition(input.vertexID);
+        output.texcoord = GetNormalizedFullScreenTriangleTexCoord(input.vertexID);
+        return output;
+    }
+    ENDHLSL
+
     SubShader
     {
         Tags
         {
             "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline"
         }
+
         Pass
         {
             ZTest Always
             Cull Off
             ZWrite Off
-            
+
             HLSLPROGRAM
-            #pragma vertex vert
-            #pragma fragment frag
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-
-            TEXTURE2D_X(_MotionVectorTexture);
-            SAMPLER(sampler_MotionVectorTexture);
-
-            struct Attributes
+            half4 Frag(Varyings input) : SV_Target
             {
-                float4 positionOS : POSITION;
-                float2 uv         : TEXCOORD0;
-            };
+                if (_DebugMotionVectorValid < 0.5f)
+                    return half4(0.8, 0.0, 0.8, 1.0);
 
-            struct Varyings
-            {
-                float4 positionHCS : SV_POSITION;
-                float2 uv          : TEXCOORD0;
-            };
+                float2 motion = SAMPLE_TEXTURE2D_X(_MotionVectorTexture, sampler_MotionVectorTexture, input.texcoord).xy;
 
-            Varyings vert(Attributes IN)
-            {
-                Varyings OUT;
-                OUT.positionHCS = TransformObjectToHClip(IN.positionOS.xyz);
-                OUT.uv = IN.uv;
-                return OUT;
-            }
-
-            half4 frag(Varyings IN) : SV_Target
-            {
-                float2 motion = SAMPLE_TEXTURE2D_X(_MotionVectorTexture, sampler_MotionVectorTexture, IN.uv).xy;
-
-                // direction -> color, length -> intensity
-                float mag = length(motion) * 10.0;
-                float angle = atan2(motion.y, motion.x) / 3.14159;
-                float3 color = 0.5 + 0.5 * cos(float3(0, 2.094, 4.188) + angle * 6.283);
+                float mag = length(motion) * 10.0f;
+                float angle = atan2(motion.y, motion.x) / 3.14159f;
+                float3 color = 0.5f + 0.5f * cos(float3(0, 2.094f, 4.188f) + angle * 6.283f);
                 return half4(color * saturate(mag), 1.0);
             }
             ENDHLSL

--- a/Shaders/PostProcessing/DebugMotionVectors.shader
+++ b/Shaders/PostProcessing/DebugMotionVectors.shader
@@ -53,6 +53,8 @@
             HLSLPROGRAM
             half4 Frag(Varyings input) : SV_Target
             {
+                UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
                 if (_DebugMotionVectorValid < 0.5f)
                     return half4(0.8, 0.0, 0.8, 1.0);
 

--- a/Shaders/ScreenSpaceLighting/ScreenSpaceGlobalIllumination.compute
+++ b/Shaders/ScreenSpaceLighting/ScreenSpaceGlobalIllumination.compute
@@ -48,6 +48,8 @@ CBUFFER_START(UnityScreenSpaceGlobalIllumination)
 
     int _RayMarchingFallbackHierarchy;
     int _IndirectDiffuseFrameIndex;
+    float _RayMarchingLowResPercentageInv;
+    int _RayMarchingLowResPadding;
 CBUFFER_END
 
 #define RAYMARCHINGFALLBACKHIERARCHY_REFLECTION_PROBES_AND_SKY (3)
@@ -57,6 +59,11 @@ CBUFFER_END
 
 // Output texture that holds the hit point NDC coordinates
 RW_TEXTURE2D_X(float2, _IndirectDiffuseHitPointTextureRW);
+
+uint2 GetLowResCoord(uint2 inputCoord)
+{
+    return min((uint2)round((float2)(inputCoord + 0.5f) * _RayMarchingLowResPercentageInv), (uint2)_ScreenSize.xy - 1u);
+}
 
 // Epslon value used for the computation
 #define RAY_TRACE_EPS 0.00024414
@@ -220,7 +227,7 @@ void TRACE_GLOBAL_ILLUMINATION(uint3 dispatchThreadId : SV_DispatchThreadID, uin
 
 #if HALF_RES
     // Compute the full resolution pixel for the inputs that do not have a pyramid
-    inputCoord = inputCoord * 2;
+    inputCoord = GetLowResCoord(inputCoord);
 #endif
 
     // Read the depth value as early as possible
@@ -292,7 +299,7 @@ void REPROJECT_GLOBAL_ILLUMINATION(uint3 dispatchThreadId : SV_DispatchThreadID,
     uint2 currentCoord = dispatchThreadId.xy;
 #if HALF_RES
     // Compute the full resolution pixel for the inputs that do not have a pyramid
-    inputCoord = inputCoord * 2;
+    inputCoord = GetLowResCoord(inputCoord);
 #endif
 
     // Read the depth and compute the position

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
-{
+﻿{
   "name": "com.kurisu.illusion-render-pipelines",
   "displayName": "Illusion RP",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "unity": "6000.3",
   "description": "Unity high-definition graphics plugin for Universal Render Pipelines.",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "com.kurisu.illusion-render-pipelines",
   "displayName": "Illusion RP",
   "version": "1.2.4",


### PR DESCRIPTION
- Fix SSGI half-resolution ray tracing and reprojection coordinate mapping by using the same representative low-resolution pixel mapping as HDRP.
- Fix color pyramid render target sizing under render scale and dynamic resolution by using the camera target descriptor size.
- Fix Motion Vectors Debug output under URP RenderGraph by rendering through a temporary debug texture before the final camera-color blit.
- Fix `_TaaFrameInfo` channel ordering so SSR blue-noise sampling uses the frame count while PCSS and per-object shadow jitter use the TAA frame index.