### PR TITLE
fix: support PRT GBuffer capture on Unity 6

### DIFF
--- a/Editor/RenderPipeline/PrecomputeRadianceTransfer/PRTBaker.cs
+++ b/Editor/RenderPipeline/PrecomputeRadianceTransfer/PRTBaker.cs
@@ -119,6 +119,41 @@ namespace Illusion.Rendering.Editor
             OnProgressUpdate?.Invoke(status, progress);
         }
 
+        private static void CopyTextureProperty(Material sourceMaterial, Material captureMaterial, string sourceProperty)
+        {
+            if (!sourceMaterial.HasProperty(sourceProperty))
+            {
+                return;
+            }
+
+            var texture = sourceMaterial.GetTexture(sourceProperty);
+            if (!texture)
+            {
+                return;
+            }
+
+            captureMaterial.SetTexture("_MainTex", texture);
+            captureMaterial.SetTextureScale("_MainTex", sourceMaterial.GetTextureScale(sourceProperty));
+            captureMaterial.SetTextureOffset("_MainTex", sourceMaterial.GetTextureOffset(sourceProperty));
+        }
+
+        private static void CopyColorProperty(Material sourceMaterial, Material captureMaterial, string sourceProperty)
+        {
+            if (sourceMaterial.HasProperty(sourceProperty))
+            {
+                captureMaterial.SetColor("_Color", sourceMaterial.GetColor(sourceProperty));
+            }
+        }
+
+        private static void CopyAlbedoProperties(Material sourceMaterial, Material captureMaterial)
+        {
+            CopyTextureProperty(sourceMaterial, captureMaterial, "_MainTex");
+            CopyTextureProperty(sourceMaterial, captureMaterial, "_BaseMap");
+            CopyTextureProperty(sourceMaterial, captureMaterial, "_BaseColorMap");
+            CopyColorProperty(sourceMaterial, captureMaterial, "_Color");
+            CopyColorProperty(sourceMaterial, captureMaterial, "_BaseColor");
+        }
+
         private void CreateCaptureDrawItems(Renderer[] renderers, Shader captureShader)
         {
             var drawItems = new List<PRTGBufferCaptureDrawItem>();
@@ -143,6 +178,7 @@ namespace Illusion.Rendering.Editor
                         shader = captureShader,
                         hideFlags = HideFlags.HideAndDontSave
                     };
+                    CopyAlbedoProperties(sourceMaterial, captureMaterial);
                     _captureMaterials.Add(captureMaterial);
                     drawItems.Add(new PRTGBufferCaptureDrawItem(renderer, captureMaterial, submeshIndex));
                 }

--- a/Editor/RenderPipeline/PrecomputeRadianceTransfer/PRTBaker.cs
+++ b/Editor/RenderPipeline/PrecomputeRadianceTransfer/PRTBaker.cs
@@ -384,11 +384,10 @@ namespace Illusion.Rendering.Editor
                 return;
             }
 
-            Renderer[] renderers = UObject.FindObjectsByType(typeof(Renderer), FindObjectsSortMode.None)
-                .OfType<Renderer>().Where(r => ContributesGI(r.gameObject))
+            Renderer[] renderers = UObject.FindObjectsByType<Renderer>(FindObjectsSortMode.None)
+                .Where(r => ContributesGI(r.gameObject))
                 .ToArray();
-            LODGroup[] lodGroups = UObject.FindObjectsByType(typeof(LODGroup))
-                .OfType<LODGroup>()
+            LODGroup[] lodGroups = UObject.FindObjectsByType<LODGroup>(FindObjectsSortMode.None)
                 .ToArray();
             renderers = SelectHighestDetailLodRenderers(renderers, lodGroups);
             var captureShader = Shader.Find(IllusionShaders.ProbeGBuffer);

--- a/Editor/RenderPipeline/PrecomputeRadianceTransfer/PRTBaker.cs
+++ b/Editor/RenderPipeline/PrecomputeRadianceTransfer/PRTBaker.cs
@@ -332,6 +332,50 @@ namespace Illusion.Rendering.Editor
 
         private static bool ContributesGI(GameObject go) => (GameObjectUtility.GetStaticEditorFlags(go) & StaticEditorFlags.ContributeGI) != 0;
 
+        internal static Renderer[] SelectHighestDetailLodRenderers(Renderer[] renderers, LODGroup[] lodGroups)
+        {
+            var lodRenderers = new HashSet<Renderer>();
+            var highestDetailRenderers = new HashSet<Renderer>();
+
+            foreach (var lodGroup in lodGroups)
+            {
+                if (!lodGroup)
+                {
+                    continue;
+                }
+
+                var lods = lodGroup.GetLODs();
+                foreach (var lod in lods)
+                {
+                    foreach (var renderer in lod.renderers)
+                    {
+                        if (renderer)
+                        {
+                            lodRenderers.Add(renderer);
+                        }
+                    }
+                }
+
+                if (lods.Length == 0)
+                {
+                    continue;
+                }
+
+                foreach (var renderer in lods[0].renderers)
+                {
+                    if (renderer)
+                    {
+                        highestDetailRenderers.Add(renderer);
+                    }
+                }
+            }
+
+            return renderers
+                .Where(renderer => renderer &&
+                                   (!lodRenderers.Contains(renderer) || highestDetailRenderers.Contains(renderer)))
+                .ToArray();
+        }
+
         public async Task BakeVolume(PRTProbeVolume volume, CancellationToken cancellationToken = default)
         {
             if (!IsInitialized())
@@ -343,6 +387,10 @@ namespace Illusion.Rendering.Editor
             Renderer[] renderers = UObject.FindObjectsByType(typeof(Renderer), FindObjectsSortMode.None)
                 .OfType<Renderer>().Where(r => ContributesGI(r.gameObject))
                 .ToArray();
+            LODGroup[] lodGroups = UObject.FindObjectsByType(typeof(LODGroup))
+                .OfType<LODGroup>()
+                .ToArray();
+            renderers = SelectHighestDetailLodRenderers(renderers, lodGroups);
             var captureShader = Shader.Find(IllusionShaders.ProbeGBuffer);
             CreateCaptureDrawItems(renderers, captureShader);
             _cubemapCamera = CreateCubemapCamera();

--- a/Editor/RenderPipeline/PrecomputeRadianceTransfer/PRTBaker.cs
+++ b/Editor/RenderPipeline/PrecomputeRadianceTransfer/PRTBaker.cs
@@ -50,12 +50,11 @@ namespace Illusion.Rendering.Editor
 
         private bool _disposed;
 
-        private Renderer[] _renderers;
-
-        // Dictionary to store original shaders for restoration
-        private readonly Dictionary<Material, Shader> _originalShaders = new();
-
         private Camera _cubemapCamera;
+
+        private PRTGBufferCaptureDrawItem[] _captureDrawItems;
+
+        private readonly List<Material> _captureMaterials = new();
 
         private readonly ComputeShader _surfelSampleCS;
 
@@ -120,57 +119,47 @@ namespace Illusion.Rendering.Editor
             OnProgressUpdate?.Invoke(status, progress);
         }
 
-        /// <summary>
-        /// Batch set shader for all game objects in the scene and record original shaders
-        /// </summary>
-        /// <param name="renderers">Array of renderer to modify</param>
-        /// <param name="shader">Shader to apply</param>
-        private void RecordAndSetShaders(Renderer[] renderers, Shader shader)
+        private void CreateCaptureDrawItems(Renderer[] renderers, Shader captureShader)
         {
-            // Record
+            var drawItems = new List<PRTGBufferCaptureDrawItem>();
             foreach (var renderer in renderers)
             {
-                var materials = renderer.sharedMaterials;
-                if (renderer && materials.Length > 0)
+                if (!renderer || !renderer.enabled || renderer.forceRenderingOff || !renderer.gameObject.activeInHierarchy)
                 {
-                    foreach (var material in materials)
+                    continue;
+                }
+
+                var materials = renderer.sharedMaterials;
+                for (int submeshIndex = 0; submeshIndex < materials.Length; submeshIndex++)
+                {
+                    var sourceMaterial = materials[submeshIndex];
+                    if (!sourceMaterial)
                     {
-                        _originalShaders[material] = renderer.sharedMaterial.shader;
+                        continue;
                     }
+
+                    var captureMaterial = new Material(sourceMaterial)
+                    {
+                        shader = captureShader,
+                        hideFlags = HideFlags.HideAndDontSave
+                    };
+                    _captureMaterials.Add(captureMaterial);
+                    drawItems.Add(new PRTGBufferCaptureDrawItem(renderer, captureMaterial, submeshIndex));
                 }
             }
 
-            // Set
-            foreach (var renderer in renderers)
-            {
-                var materials = renderer.sharedMaterials;
-                if (renderer && materials.Length > 0)
-                {
-                    foreach (var material in materials)
-                    {
-                        material.shader = shader;
-                    }
-                }
-            }
+            _captureDrawItems = drawItems.ToArray();
         }
 
-        /// <summary>
-        /// Restore original shaders for all materials
-        /// </summary>
-        private void RestoreOriginalShaders()
+        private void DestroyCaptureDrawItems()
         {
-            foreach (var kvp in _originalShaders)
+            foreach (var material in _captureMaterials)
             {
-                var material = kvp.Key;
-                var originalShader = kvp.Value;
-
-                if (material && originalShader)
-                {
-                    material.shader = originalShader;
-                }
+                UObject.DestroyImmediate(material);
             }
 
-            _originalShaders.Clear();
+            _captureMaterials.Clear();
+            _captureDrawItems = null;
         }
 
         /// <summary>
@@ -224,17 +213,26 @@ namespace Illusion.Rendering.Editor
         private void CaptureGbufferCubemaps(Vector3 position)
         {
             _cubemapCamera.transform.SetPositionAndRotation(position, Quaternion.identity);
+            int originalCullingMask = _cubemapCamera.cullingMask;
+            _cubemapCamera.cullingMask = 0;
 
-            // Capture GBuffers
-            SetGlobalGBufferCaptureMode(GBufferCaptureMode.WorldPosition);
-            _cubemapCamera.RenderToCubemap(_worldPosRT, -1, StaticEditorFlags.ContributeGI);
-            SetGlobalGBufferCaptureMode(GBufferCaptureMode.Normal);
-            _cubemapCamera.RenderToCubemap(_normalRT, -1, StaticEditorFlags.ContributeGI);
-            SetGlobalGBufferCaptureMode(GBufferCaptureMode.Albedo);
-            _cubemapCamera.RenderToCubemap(_albedoRT, -1, StaticEditorFlags.ContributeGI);
-
-            // Clean up global keywords after capture
-            ClearGlobalGBufferKeywords();
+            try
+            {
+                using (PRTGBufferCaptureBridge.Begin(_cubemapCamera, _captureDrawItems))
+                {
+                    SetGlobalGBufferCaptureMode(GBufferCaptureMode.WorldPosition);
+                    _cubemapCamera.RenderToCubemap(_worldPosRT, -1, StaticEditorFlags.ContributeGI);
+                    SetGlobalGBufferCaptureMode(GBufferCaptureMode.Normal);
+                    _cubemapCamera.RenderToCubemap(_normalRT, -1, StaticEditorFlags.ContributeGI);
+                    SetGlobalGBufferCaptureMode(GBufferCaptureMode.Albedo);
+                    _cubemapCamera.RenderToCubemap(_albedoRT, -1, StaticEditorFlags.ContributeGI);
+                }
+            }
+            finally
+            {
+                ClearGlobalGBufferKeywords();
+                _cubemapCamera.cullingMask = originalCullingMask;
+            }
 
             // Force GPU to flush and release temporary resources
             GL.Flush();
@@ -346,7 +344,7 @@ namespace Illusion.Rendering.Editor
                 .OfType<Renderer>().Where(r => ContributesGI(r.gameObject))
                 .ToArray();
             var captureShader = Shader.Find(IllusionShaders.ProbeGBuffer);
-            RecordAndSetShaders(renderers, captureShader);
+            CreateCaptureDrawItems(renderers, captureShader);
             _cubemapCamera = CreateCubemapCamera();
             try
             {
@@ -354,8 +352,7 @@ namespace Illusion.Rendering.Editor
             }
             finally
             {
-                RestoreOriginalShaders();
-                // Clean up temporary camera
+                DestroyCaptureDrawItems();
                 UObject.DestroyImmediate(_cubemapCamera.gameObject);
                 _cubemapCamera = null;
             }

--- a/Runtime/RenderPipeline/IllusionRendererFeature.PRTCapture.cs
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.PRTCapture.cs
@@ -1,0 +1,129 @@
+#if UNITY_EDITOR
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.RenderGraphModule;
+using UnityEngine.Rendering.Universal;
+
+namespace Illusion.Rendering
+{
+    internal readonly struct PRTGBufferCaptureDrawItem
+    {
+        internal readonly Renderer Renderer;
+        internal readonly Material Material;
+        internal readonly int SubmeshIndex;
+
+        internal PRTGBufferCaptureDrawItem(Renderer renderer, Material material, int submeshIndex)
+        {
+            Renderer = renderer;
+            Material = material;
+            SubmeshIndex = submeshIndex;
+        }
+    }
+
+    internal static class PRTGBufferCaptureBridge
+    {
+        private static Camera _camera;
+        private static PRTGBufferCaptureDrawItem[] _drawItems;
+
+        internal static IDisposable Begin(Camera camera, PRTGBufferCaptureDrawItem[] drawItems)
+        {
+            _camera = camera;
+            _drawItems = drawItems;
+            return new Scope(camera);
+        }
+
+        internal static bool TryGet(Camera camera, out PRTGBufferCaptureDrawItem[] drawItems)
+        {
+            if (_camera == camera && _drawItems != null)
+            {
+                drawItems = _drawItems;
+                return true;
+            }
+
+            drawItems = null;
+            return false;
+        }
+
+        private sealed class Scope : IDisposable
+        {
+            private readonly Camera _scopeCamera;
+
+            internal Scope(Camera camera)
+            {
+                _scopeCamera = camera;
+            }
+
+            public void Dispose()
+            {
+                if (_camera != _scopeCamera)
+                {
+                    return;
+                }
+
+                _camera = null;
+                _drawItems = null;
+            }
+        }
+    }
+
+    internal sealed class PRTGBufferCapturePass : ScriptableRenderPass
+    {
+        private static readonly ProfilingSampler ProfilingSampler = new("PRT GBuffer Capture");
+
+        private sealed class PassData
+        {
+            internal PRTGBufferCaptureDrawItem[] DrawItems;
+            internal Matrix4x4 ViewMatrix;
+            internal Matrix4x4 ProjectionMatrix;
+            internal Rect Viewport;
+        }
+
+        internal PRTGBufferCapturePass()
+        {
+            renderPassEvent = RenderPassEvent.AfterRendering;
+        }
+
+        public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+        {
+            var cameraData = frameData.Get<UniversalCameraData>();
+            if (!PRTGBufferCaptureBridge.TryGet(cameraData.camera, out var drawItems))
+            {
+                return;
+            }
+
+            var resourceData = frameData.Get<UniversalResourceData>();
+            using var builder = renderGraph.AddRasterRenderPass<PassData>(
+                "PRT GBuffer Capture", out var passData, ProfilingSampler);
+
+            builder.SetRenderAttachment(resourceData.activeColorTexture, 0, AccessFlags.Write);
+            builder.SetRenderAttachmentDepth(resourceData.activeDepthTexture, AccessFlags.Write);
+
+            passData.DrawItems = drawItems;
+            passData.ViewMatrix = cameraData.GetViewMatrix();
+            passData.ProjectionMatrix = cameraData.GetProjectionMatrix();
+            passData.Viewport = new Rect(0.0f, 0.0f,
+                cameraData.cameraTargetDescriptor.width, cameraData.cameraTargetDescriptor.height);
+
+            builder.AllowPassCulling(false);
+            builder.SetRenderFunc(static (PassData data, RasterGraphContext context) =>
+            {
+                context.cmd.ClearRenderTarget(RTClearFlags.All, Color.clear, 1.0f, 0);
+                context.cmd.SetViewProjectionMatrices(data.ViewMatrix, data.ProjectionMatrix);
+                context.cmd.SetViewport(data.Viewport);
+
+                foreach (var item in data.DrawItems)
+                {
+                    var renderer = item.Renderer;
+                    if (!renderer || !renderer.enabled || renderer.forceRenderingOff || !renderer.gameObject.activeInHierarchy)
+                    {
+                        continue;
+                    }
+
+                    context.cmd.DrawRenderer(renderer, item.Material, item.SubmeshIndex, 0);
+                }
+            });
+        }
+    }
+}
+#endif

--- a/Runtime/RenderPipeline/IllusionRendererFeature.PRTCapture.cs.meta
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.PRTCapture.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ebd2f107319c20f409975bd6d78c0ab3

--- a/Runtime/RenderPipeline/IllusionRendererFeature.cs
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.cs
@@ -226,6 +226,10 @@ namespace Illusion.Rendering
 
         private SetKeywordPass _disablePRTGIPass;
 
+#if UNITY_EDITOR
+        private PRTGBufferCapturePass _prtGBufferCapturePass;
+#endif
+
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
         private ExposureDebugPass _exposureDebugPass;
         
@@ -320,6 +324,10 @@ namespace Illusion.Rendering
             _setupPass = new SetupPass(this, _rendererData);
             _transparentStencilVRSPass = new StencilVRSGenerationPass(IllusionRenderPassEvent.TransparentStencilVRSPass);
 
+#if UNITY_EDITOR
+            _prtGBufferCapturePass = new PRTGBufferCapturePass();
+#endif
+
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             _exposureDebugPass = new ExposureDebugPass(_rendererData);
             _motionVectorsDebugPass = new MotionVectorsDebugPass(_rendererData);
@@ -329,6 +337,14 @@ namespace Illusion.Rendering
 
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
         {
+#if UNITY_EDITOR
+            if (PRTGBufferCaptureBridge.TryGet(renderingData.cameraData.camera, out _))
+            {
+                renderer.EnqueuePass(_prtGBufferCapturePass);
+                return;
+            }
+#endif
+
             var config = IllusionRuntimeRenderingConfig.Get();
             bool isPreviewCamera = renderingData.cameraData.cameraType == CameraType.Preview;
             bool isGameCamera = renderingData.cameraData.cameraType == CameraType.Game;
@@ -638,6 +654,10 @@ namespace Illusion.Rendering
             SafeDispose(ref _exposurePass);
             SafeDispose(ref _prtRelightPass);
             SafeDispose(ref _setupPass);
+
+#if UNITY_EDITOR
+            _prtGBufferCapturePass = null;
+#endif
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             SafeDispose(ref _stencilVRSDebugPass);


### PR DESCRIPTION
## Summary

Fixes the invalid PRT bake output on Unity 6 / URP 17 by replacing the legacy shader-swapping capture path with a dedicated editor-only URP RenderGraph capture pass.

Closes #43.

## Changes

- Add an editor-only `PRTGBufferCapturePass` that runs for the temporary cubemap capture camera only.
- Keep `Camera.RenderToCubemap` for Unity's cubemap-face camera setup, while explicitly drawing active `ContributeGI` renderers into the capture targets.
- Clone source materials and assign `Hidden/ProbeGBuffer` to the clones instead of temporarily modifying scene materials.
- Use `UniversalCameraData` view/projection matrices for the RenderGraph pass.
- Scope the capture registration and clean up temporary materials, global keywords, camera state, and draw items after baking.

## Validation

Tested in the Sponza scene with:

- Unity `6000.3.17f1`
- URP `17.3.0`
- Windows / Direct3D 12

After regenerating the PRT data:

- 82,790 surfels total
- 73,166 valid geometry surfels
- 9,624 sky surfels
- 1,009 bricks
- 14,150 factors
- 180 valid probes

These results are consistent with the previously committed Unity 2022 bake (~82,858 surfels, ~73,238 valid geometry surfels, and ~9,620 sky surfels). Small differences are expected because surfel sampling uses random seeds.