### PR TITLE
feat: add Transparent SSR support for Water

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,16 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+.gitattributes text eol=lf
+
+# Unity shader sources use CRLF in this Windows-first repository. Keeping the
+# checkout format explicit prevents editors and patch tools from mixing LF and
+# CRLF inside the same source file.
+*.shader text eol=crlf
+*.hlsl text eol=crlf
+*.compute text eol=crlf
+*.cginc text eol=crlf
+
+# Git invokes this entry point through its POSIX shell, so its shebang must
+# remain LF even when core.autocrlf is enabled.
+.githooks/pre-commit text eol=lf
+.githooks/*.ps1 text eol=crlf

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,29 @@
+# Repository Git hooks
+
+Enable the versioned hooks once after cloning:
+
+```powershell
+& .\.githooks\install.ps1
+```
+
+The pre-commit hook checks files included in the commit and rejects files that
+mix CRLF, LF, or standalone CR line endings. It checks the working-tree bytes
+because Git may normalize the staged blob before the hook runs.
+
+To scan every tracked file manually:
+
+```powershell
+& .\.githooks\check-line-endings.ps1 -All
+```
+
+To normalize selected files to the repository's Windows convention:
+
+```powershell
+& .\.githooks\normalize-line-endings.ps1 -Style CRLF -Path @(
+    "Shaders/Example.shader",
+    "Shaders/Example.hlsl"
+)
+```
+
+The pre-commit hook never rewrites or stages files automatically, so partial
+staging remains safe.

--- a/.githooks/check-line-endings.ps1
+++ b/.githooks/check-line-endings.ps1
@@ -1,0 +1,102 @@
+[CmdletBinding()]
+param(
+    [switch] $All
+)
+
+$repoRoot = (& git rev-parse --show-toplevel 2>$null)
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRoot))
+{
+    Write-Host "line-ending check: unable to locate the Git repository." -ForegroundColor Red
+    exit 1
+}
+
+Push-Location $repoRoot
+try
+{
+    if ($All)
+    {
+        $paths = @(& git -c core.quotepath=false ls-files --cached)
+    }
+    else
+    {
+        # Inspect the working-tree version of files participating in this commit.
+        # This catches mixed endings produced by editors or patch tools even when
+        # Git's clean conversion would normalize the staged blob.
+        $paths = @(& git -c core.quotepath=false diff --cached --name-only --diff-filter=ACMR --no-renames)
+    }
+
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Host "line-ending check: unable to enumerate files." -ForegroundColor Red
+        exit 1
+    }
+
+    $invalidFiles = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($relativePath in $paths)
+    {
+        if ([string]::IsNullOrWhiteSpace($relativePath) -or -not (Test-Path -LiteralPath $relativePath -PathType Leaf))
+        {
+            continue
+        }
+
+        $bytes = [IO.File]::ReadAllBytes((Resolve-Path -LiteralPath $relativePath))
+        if ($bytes.Length -eq 0 -or [Array]::IndexOf($bytes, [byte] 0) -ge 0)
+        {
+            continue
+        }
+
+        $crlfCount = 0
+        $lfCount = 0
+        $crCount = 0
+
+        for ($index = 0; $index -lt $bytes.Length; $index++)
+        {
+            if ($bytes[$index] -eq 13)
+            {
+                if (($index + 1) -lt $bytes.Length -and $bytes[$index + 1] -eq 10)
+                {
+                    $crlfCount++
+                    $index++
+                }
+                else
+                {
+                    $crCount++
+                }
+            }
+            elseif ($bytes[$index] -eq 10)
+            {
+                $lfCount++
+            }
+        }
+
+        if (($crlfCount -gt 0 -and $lfCount -gt 0) -or $crCount -gt 0)
+        {
+            $invalidFiles.Add([PSCustomObject]@{
+                Path = $relativePath
+                CRLF = $crlfCount
+                LF = $lfCount
+                CR = $crCount
+            })
+        }
+    }
+
+    if ($invalidFiles.Count -gt 0)
+    {
+        Write-Host "Commit blocked: inconsistent line endings were found:" -ForegroundColor Red
+        foreach ($file in $invalidFiles)
+        {
+            Write-Host ("  {0} (CRLF={1}, LF={2}, CR={3})" -f $file.Path, $file.CRLF, $file.LF, $file.CR)
+        }
+
+        Write-Host "Normalize each file to a single line-ending style, stage it again, and retry." -ForegroundColor Yellow
+        Write-Host "For this repository's Windows convention, use .githooks/normalize-line-endings.ps1." -ForegroundColor Yellow
+        exit 1
+    }
+
+    exit 0
+}
+finally
+{
+    Pop-Location
+}

--- a/.githooks/install.ps1
+++ b/.githooks/install.ps1
@@ -1,0 +1,18 @@
+[CmdletBinding()]
+param()
+
+$repoRoot = (& git rev-parse --show-toplevel 2>$null)
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRoot))
+{
+    Write-Error "Unable to locate the Git repository."
+    exit 1
+}
+
+git -C $repoRoot config core.hooksPath .githooks
+if ($LASTEXITCODE -ne 0)
+{
+    Write-Error "Unable to configure core.hooksPath."
+    exit 1
+}
+
+Write-Host "Git hooks enabled for $repoRoot"

--- a/.githooks/normalize-line-endings.ps1
+++ b/.githooks/normalize-line-endings.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("CRLF", "LF")]
+    [string] $Style = "CRLF",
+
+    [Parameter(Mandatory, Position = 0)]
+    [string[]] $Path
+)
+
+$lineEnding = if ($Style -eq "CRLF") { [byte[]] (13, 10) } else { [byte[]] (10) }
+
+foreach ($item in $Path)
+{
+    $resolvedPath = Resolve-Path -LiteralPath $item -ErrorAction Stop
+    $bytes = [IO.File]::ReadAllBytes($resolvedPath)
+
+    if ([Array]::IndexOf($bytes, [byte] 0) -ge 0)
+    {
+        throw "Refusing to normalize binary file: $item"
+    }
+
+    $output = [IO.MemoryStream]::new($bytes.Length + 16)
+    try
+    {
+        for ($index = 0; $index -lt $bytes.Length; $index++)
+        {
+            if ($bytes[$index] -eq 13)
+            {
+                if (($index + 1) -lt $bytes.Length -and $bytes[$index + 1] -eq 10)
+                {
+                    $index++
+                }
+
+                $output.Write($lineEnding, 0, $lineEnding.Length)
+            }
+            elseif ($bytes[$index] -eq 10)
+            {
+                $output.Write($lineEnding, 0, $lineEnding.Length)
+            }
+            else
+            {
+                $output.WriteByte($bytes[$index])
+            }
+        }
+
+        [IO.File]::WriteAllBytes($resolvedPath, $output.ToArray())
+    }
+    finally
+    {
+        $output.Dispose()
+    }
+
+    Write-Host "Normalized $item to $Style."
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+hook_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+checker="$hook_dir/check-line-endings.ps1"
+
+if command -v pwsh >/dev/null 2>&1; then
+    exec pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$checker"
+fi
+
+if command -v powershell.exe >/dev/null 2>&1; then
+    exec powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "$checker"
+fi
+
+echo "pre-commit: PowerShell is required to check line endings." >&2
+exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add temporal capture readiness reporting for screenshot warmup across TAA, SSGI, SSR, and screen-space shadows.
+- Add transparent screen-space reflections for water surfaces, including water surface data rendering and debug visualization.
+- Add a pre-refraction scene color copy for forward screen-space refraction.
 
 ### Changed
 

--- a/Editor/Material/HybridLitShader.cs
+++ b/Editor/Material/HybridLitShader.cs
@@ -3,6 +3,7 @@ using UnityEditor;
 using UnityEditor.Rendering;
 using UnityEditor.Rendering.Universal.ShaderGUI;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Illusion.Rendering.Editor
 {
@@ -184,6 +185,58 @@ namespace Illusion.Rendering.Editor
                     DrawQueueOffsetField();
             }
             materialEditor.EnableInstancingField();
+        }
+    }
+
+    internal static class WaterReflectionModeMaterialState
+    {
+        private const string LegacyKeyword = "_WATER_REFLECTION_LEGACY";
+        private const string WaterSsrDataPass = "WaterSSRData";
+
+        internal static void Synchronize(Material material)
+        {
+            if (material == null || !material.HasProperty(IllusionShaderProperties.WaterReflectionMode))
+                return;
+
+            bool useLegacyReflection = material.GetFloat(IllusionShaderProperties.WaterReflectionMode) > 0.5f;
+            if (material.IsKeywordEnabled(LegacyKeyword) != useLegacyReflection)
+                CoreUtils.SetKeyword(material, LegacyKeyword, useLegacyReflection);
+
+            bool enableWaterSsrData = !useLegacyReflection;
+            if (material.GetShaderPassEnabled(WaterSsrDataPass) != enableWaterSsrData)
+                material.SetShaderPassEnabled(WaterSsrDataPass, enableWaterSsrData);
+        }
+    }
+
+    internal sealed class WaterReflectionModeDrawer : MaterialPropertyDrawer
+    {
+        private static readonly string[] ModeNames = { "Screen Space", "Legacy" };
+
+        private static readonly GUIContent Label = new(
+            "Water Reflection Mode",
+            "Uses the reflection implementation provided by the Water shader.");
+
+        public override void OnGUI(Rect position, MaterialProperty prop, string label, MaterialEditor editor)
+        {
+            int mode = Mathf.Clamp(Mathf.RoundToInt(prop.floatValue), 0, ModeNames.Length - 1);
+
+            EditorGUI.BeginChangeCheck();
+            EditorGUI.showMixedValue = prop.hasMixedValue;
+            Rect popupPosition = EditorGUI.PrefixLabel(position, Label);
+            mode = EditorGUI.Popup(popupPosition, mode, ModeNames);
+            EditorGUI.showMixedValue = false;
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                editor.RegisterPropertyChangeUndo(Label.text);
+                prop.floatValue = mode;
+            }
+
+            foreach (UnityEngine.Object target in editor.targets)
+            {
+                if (target is Material material)
+                    WaterReflectionModeMaterialState.Synchronize(material);
+            }
         }
     }
 }

--- a/Editor/RenderPipeline/IllusionRendererFeatureEditor.cs
+++ b/Editor/RenderPipeline/IllusionRendererFeatureEditor.cs
@@ -17,6 +17,8 @@ namespace Illusion.Rendering.Editor
         private SerializedProperty _oitFilterLayer;
         private SerializedProperty _oitOverrideStencil;
         private SerializedProperty _transparentDepthPostPass;
+        private SerializedProperty _screenSpaceRefraction;
+        private SerializedProperty _transparentScreenSpaceReflection;
         private SerializedProperty _oitTransparentOverdrawPass;
 
         // Character Rendering Settings
@@ -56,6 +58,8 @@ namespace Illusion.Rendering.Editor
             _oitFilterLayer = Properties.Find(feature => feature.oitFilterLayer);
             _oitOverrideStencil = Properties.Find(feature => feature.oitOverrideStencil);
             _transparentDepthPostPass = Properties.Find(feature => feature.transparentDepthPostPass);
+            _screenSpaceRefraction = Properties.Find(feature => feature.screenSpaceRefraction);
+            _transparentScreenSpaceReflection = Properties.Find(feature => feature.transparentScreenSpaceReflection);
             _oitTransparentOverdrawPass = Properties.Find(feature => feature.oitTransparentOverdrawPass);
 
             // Character Rendering Settings
@@ -129,6 +133,8 @@ namespace Illusion.Rendering.Editor
             if (Foldout("Transparency", true))
             {
                 EditorGUILayout.PropertyField(_transparentDepthPostPass, Styles.TransparentDepthPostPassLabel);
+                EditorGUILayout.PropertyField(_screenSpaceRefraction, Styles.ScreenSpaceRefractionLabel);
+                EditorGUILayout.PropertyField(_transparentScreenSpaceReflection, Styles.TransparentScreenSpaceReflectionLabel);
                 EditorGUILayout.PropertyField(_orderIndependentTransparency, Styles.OrderIndependentTransparencyLabel);
                 if (_orderIndependentTransparency.boolValue)
                 {
@@ -217,6 +223,10 @@ namespace Illusion.Rendering.Editor
                 "Override the stencil state for the transparent overdraw pass.");
             public static readonly GUIContent TransparentDepthPostPassLabel = new("Transparent Depth Post Pass",
                 "Enable to write transparent depth after depth prepass.");
+            public static readonly GUIContent ScreenSpaceRefractionLabel = new("Screen Space Refraction",
+                "Copy opaque scene color for supported refractive shaders.");
+            public static readonly GUIContent TransparentScreenSpaceReflectionLabel = new("Transparent Screen Space Reflection",
+                "Enable screen space reflections for supported transparent surfaces.");
             public static readonly GUIContent OitTransparentOverdrawPassLabel = new("OIT Transparent Overdraw Pass",
                 "Enable to overdraw universal transparent objects after rendering OIT objects.");
 

--- a/Editor/RenderPipeline/IllusionRenderingDebugger.cs
+++ b/Editor/RenderPipeline/IllusionRenderingDebugger.cs
@@ -57,6 +57,14 @@ namespace Illusion.Rendering.Editor
                 new GUIContent("Screen Space Reflection", "Enable/Disable SSR"),
                 _config.EnableScreenSpaceReflection);
 
+            _config.EnableTransparentScreenSpaceReflection = EditorGUILayout.ToggleLeft(
+                new GUIContent("Transparent Screen Space Reflection", "Enable screen space reflections for supported transparent water shaders"),
+                _config.EnableTransparentScreenSpaceReflection);
+
+            _config.EnableScreenSpaceRefraction = EditorGUILayout.ToggleLeft(
+                new GUIContent("Screen Space Refraction", "Copy opaque scene color for supported refractive shaders"),
+                _config.EnableScreenSpaceRefraction);
+
             _config.EnableScreenSpaceGlobalIllumination = EditorGUILayout.ToggleLeft(
                 new GUIContent("Screen Space Global Illumination", "Enable/Disable SSGI"),
                 _config.EnableScreenSpaceGlobalIllumination);
@@ -109,6 +117,10 @@ namespace Illusion.Rendering.Editor
             _config.EnableScreenSpaceReflectionDebug = EditorGUILayout.ToggleLeft(
                 new GUIContent("SSR Debug", "Visualize screen space reflection"),
                 _config.EnableScreenSpaceReflectionDebug);
+
+            _config.EnableTransparentScreenSpaceReflectionDebug = EditorGUILayout.ToggleLeft(
+                new GUIContent("Transparent SSR Debug", "Visualize screen space reflections for transparent water"),
+                _config.EnableTransparentScreenSpaceReflectionDebug);
 
             _config.EnablePerObjectShadowDebug = EditorGUILayout.ToggleLeft(
                 new GUIContent("Per Object Shadow Debug", "Visualize per-object shadows"),
@@ -191,6 +203,8 @@ namespace Illusion.Rendering.Editor
         private void ResetAllFeatures()
         {
             _config.EnableScreenSpaceReflection = true;
+            _config.EnableTransparentScreenSpaceReflection = true;
+            _config.EnableScreenSpaceRefraction = true;
             _config.EnableScreenSpaceGlobalIllumination = true;
             _config.EnableContactShadows = true;
             _config.EnablePercentageCloserSoftShadows = true;
@@ -206,6 +220,7 @@ namespace Illusion.Rendering.Editor
         {
             _config.EnableMotionVectorsDebug = false;
             _config.EnableScreenSpaceReflectionDebug = false;
+            _config.EnableTransparentScreenSpaceReflectionDebug = false;
             _config.ExposureDebugMode = ExposureDebugMode.None;
             _config.ScreenSpaceShadowDebugMode = ScreenSpaceShadowDebugMode.None;
             _config.EnablePerObjectShadowDebug = false;

--- a/Runtime/RenderPipeline/IllusionRenderCore.cs
+++ b/Runtime/RenderPipeline/IllusionRenderCore.cs
@@ -143,6 +143,8 @@ namespace Illusion.Rendering
         public static readonly int ScreenSpaceReflections = Shader.PropertyToID("_ScreenSpaceReflections");
 
         public static readonly int WaterReflectionMode = Shader.PropertyToID("_WaterReflectionMode");
+
+        public static readonly int _WaterPreDepthTexture = MemberNameHelpers.ShaderPropertyID();
         
         public static readonly int ScreenSpaceOcclusionTexture = Shader.PropertyToID("_ScreenSpaceOcclusionTexture");
 

--- a/Runtime/RenderPipeline/IllusionRenderCore.cs
+++ b/Runtime/RenderPipeline/IllusionRenderCore.cs
@@ -141,6 +141,8 @@ namespace Illusion.Rendering
         public static readonly int SsrLightingTexture = Shader.PropertyToID("_SsrLightingTexture");
         
         public static readonly int ScreenSpaceReflections = Shader.PropertyToID("_ScreenSpaceReflections");
+
+        public static readonly int WaterReflectionMode = Shader.PropertyToID("_WaterReflectionMode");
         
         public static readonly int ScreenSpaceOcclusionTexture = Shader.PropertyToID("_ScreenSpaceOcclusionTexture");
 

--- a/Runtime/RenderPipeline/IllusionRenderCore.cs
+++ b/Runtime/RenderPipeline/IllusionRenderCore.cs
@@ -103,6 +103,12 @@ namespace Illusion.Rendering
 
         public static readonly int _CameraDepthTexture = MemberNameHelpers.ShaderPropertyID();
 
+        public static readonly int _DepthTexture = MemberNameHelpers.ShaderPropertyID();
+
+        public static readonly int _PreRefractionColorTexture = MemberNameHelpers.ShaderPropertyID();
+
+        public static readonly int _WaterSSRNormalTexture = MemberNameHelpers.ShaderPropertyID();
+
         public static readonly int _ContactShadowMap = MemberNameHelpers.ShaderPropertyID();
 
         public static readonly int ScreenSpaceShadowmapTexture = Shader.PropertyToID("_ScreenSpaceShadowmapTexture");
@@ -289,6 +295,15 @@ namespace Illusion.Rendering
         public const RenderPassEvent SubsurfaceScatteringPass = RenderPassEvent.BeforeRenderingOpaques;
 
         public const RenderPassEvent ScreenSpaceShadowsPostPass = RenderPassEvent.AfterRenderingOpaques;
+
+        // Copy the opaque scene color for screen-space refraction.
+        public const RenderPassEvent CopyPreRefractionColorPass = RenderPassEvent.AfterRenderingOpaques + 1;
+
+        // Render water surface data for screen space reflections.
+        public const RenderPassEvent WaterSSRDataPass = RenderPassEvent.AfterRenderingOpaques + 2;
+
+        // Render screen space reflections for transparent surfaces.
+        public const RenderPassEvent TransparentScreenSpaceReflectionPass = RenderPassEvent.AfterRenderingOpaques + 3;
 
         // ==================================== Transparency =============================================== //
         public const RenderPassEvent OrderIndependentTransparentPass = RenderPassEvent.AfterRenderingTransparents + 1;

--- a/Runtime/RenderPipeline/IllusionRendererData.cs
+++ b/Runtime/RenderPipeline/IllusionRendererData.cs
@@ -235,11 +235,23 @@ namespace Illusion.Rendering
         public RTHandle DepthPyramidRT;
 
         /// <summary>
+        /// Opaque scene color for screen-space refraction.
+        /// </summary>
+        public RTHandle PreRefractionColorRT;
+
+        /// <summary>
+        /// Normal and smoothness texture for water surface screen space reflections.
+        /// </summary>
+        public RTHandle WaterSSRNormalRT;
+
+        /// <summary>
         /// Get renderer camera <see cref="UniversalAdditionalCameraData"/>.
         /// </summary>
         public UniversalAdditionalCameraData AdditionalCameraData => _additionalCameraData;
 
         public TextureHandle ScreenSpaceReflectionTexture;
+
+        public TextureHandle TransparentScreenSpaceReflectionTexture;
 
         /// <summary>
         /// Get current camera frame count.
@@ -270,6 +282,11 @@ namespace Illusion.Rendering
         /// Get whether the renderer can sample screen space reflection texture.
         /// </summary>
         public bool SampleScreenSpaceReflection { get; internal set; } = true;
+
+        /// <summary>
+        /// Get whether the renderer can sample screen space reflections for transparent surfaces.
+        /// </summary>
+        public bool SampleTransparentScreenSpaceReflection { get; internal set; }
         
         /// <summary>
         /// Whether the renderer should copy depth and normal texture for next frame usage.
@@ -540,6 +557,8 @@ namespace Illusion.Rendering
             ForwardGBufferRT?.Release();
             DebugExposureTexture?.Release();
             DepthPyramidRT?.Release();
+            PreRefractionColorRT?.Release();
+            WaterSSRNormalRT?.Release();
             CoreUtils.SafeRelease(HistogramBuffer);
             HistogramBuffer = null;
             CoreUtils.SafeRelease(_ambientProbeBuffer);

--- a/Runtime/RenderPipeline/IllusionRendererFeature.cs
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.cs
@@ -56,6 +56,16 @@ namespace Illusion.Rendering
         public bool transparentDepthPostPass = true;
 
         /// <summary>
+        /// Enable the opaque color copy used by screen-space refraction.
+        /// </summary>
+        public bool screenSpaceRefraction = true;
+
+        /// <summary>
+        /// Enable screen space reflections for supported transparent surfaces.
+        /// </summary>
+        public bool transparentScreenSpaceReflection = true;
+
+        /// <summary>
         /// Enable to overdraw universal transparent objects after rendering OIT objects, used to fix background color bleed-through.
         /// </summary>
         public bool oitTransparentOverdrawPass;
@@ -182,6 +192,12 @@ namespace Illusion.Rendering
 
         private ScreenSpaceReflectionPass _screenSpaceReflectionPass;
 
+        private ScreenSpaceReflectionPass _transparentScreenSpaceReflectionPass;
+
+        private CopyPreRefractionColorPass _copyPreRefractionColorPass;
+
+        private WaterSSRDataPass _waterSSRDataPass;
+
         private SyncGraphicsFencePass _screenSpaceReflectionSyncFencePass;
 
         private SetKeywordPass _enableScreenSpaceReflectionPass;
@@ -236,6 +252,8 @@ namespace Illusion.Rendering
         private MotionVectorsDebugPass _motionVectorsDebugPass;
                         
         private StencilVRSDebugPass _stencilVRSDebugPass;
+
+        private TransparentSSRDebugPass _transparentSSRDebugPass;
 #endif
 
         public override void Create()
@@ -296,6 +314,9 @@ namespace Illusion.Rendering
             _transparentCopyPostDepthPass = new TransparentCopyPostDepthPass();
 
             _screenSpaceReflectionPass = new ScreenSpaceReflectionPass(_rendererData);
+            _transparentScreenSpaceReflectionPass = new ScreenSpaceReflectionPass(_rendererData, true);
+            _copyPreRefractionColorPass = new CopyPreRefractionColorPass(_rendererData);
+            _waterSSRDataPass = new WaterSSRDataPass(_rendererData);
             _screenSpaceReflectionSyncFencePass = new SyncGraphicsFencePass(RenderPassEvent.BeforeRenderingOpaques, IllusionGraphicsFenceEvent.ScreenSpaceReflection, _rendererData);
             _enableScreenSpaceReflectionPass = new SetKeywordPass(IllusionShaderKeywords._SCREEN_SPACE_REFLECTION, true, RenderPassEvent.BeforeRendering);
             _disableScreenSpaceReflectionPass = new SetKeywordPass(IllusionShaderKeywords._SCREEN_SPACE_REFLECTION, false, RenderPassEvent.BeforeRendering);
@@ -332,6 +353,7 @@ namespace Illusion.Rendering
             _exposureDebugPass = new ExposureDebugPass(_rendererData);
             _motionVectorsDebugPass = new MotionVectorsDebugPass(_rendererData);
             _stencilVRSDebugPass = new StencilVRSDebugPass();
+            _transparentSSRDebugPass = new TransparentSSRDebugPass(_rendererData);
 #endif
         }
 
@@ -351,6 +373,8 @@ namespace Illusion.Rendering
             bool enableSceneShadow = !isPreviewCamera;
             bool isPostProcessEnabled = renderingData.postProcessingEnabled && renderingData.cameraData.postProcessEnabled;
             var isDeferred = UniversalRenderingUtility.GetRenderingModeActual(renderer) == RenderingMode.Deferred;
+            bool supportsTransparentSSRCompute = SystemInfo.supportsComputeShaders
+                                                 && SystemInfo.graphicsDeviceType is not GraphicsDeviceType.OpenGLES3;
 
             var contactShadowParam = VolumeManager.instance.stack.GetComponent<ContactShadows>();
             bool useContactShadows = config.EnableContactShadows
@@ -372,6 +396,10 @@ namespace Illusion.Rendering
             bool useScreenSpaceReflection = config.EnableScreenSpaceReflection
                                             && screenSpaceReflection && !isPreviewCamera
                                             && screenSpaceReflectionParam.enable.value;
+            bool useTransparentScreenSpaceReflection = useScreenSpaceReflection
+                                                        && transparentScreenSpaceReflection
+                                                        && config.EnableTransparentScreenSpaceReflection
+                                                        && supportsTransparentSSRCompute;
 
             var screenSpaceGlobalIlluminationParam = VolumeManager.instance.stack.GetComponent<ScreenSpaceGlobalIllumination>();
             bool useScreenSpaceGlobalIllumination = config.EnableScreenSpaceGlobalIllumination 
@@ -401,7 +429,8 @@ namespace Illusion.Rendering
             _rendererData.SampleProbeVolumes = usePrecomputedRadianceTransfer && hasValidVolume;
 
             bool useForwardGBuffer = !isDeferred; // Replace DepthNormal with ForwardGBuffer in Forward/Forward+.
-            bool useDepthPyramid = useAmbientOcclusion || useScreenSpaceReflection || useScreenSpaceGlobalIllumination;
+            bool useDepthPyramid = useAmbientOcclusion || useScreenSpaceReflection
+                                   || useTransparentScreenSpaceReflection || useScreenSpaceGlobalIllumination;
             bool useTAA = renderingData.cameraData.IsTemporalAAEnabled(); // Disable in scene view
             bool needHistoryColor = requireHistoryColor && !useTAA;
             bool useColorPyramid = useScreenSpaceReflection || useScreenSpaceGlobalIllumination;
@@ -500,6 +529,22 @@ namespace Illusion.Rendering
             // AfterRenderingOpaques
             renderer.EnqueuePass(_screenSpaceShadowsPostPass);
 
+            bool useScreenSpaceRefraction = screenSpaceRefraction
+                                            && config.EnableScreenSpaceRefraction
+                                            && !isPreviewCamera
+                                            && !isOffscreenDepth;
+            _copyPreRefractionColorPass.Setup(useScreenSpaceRefraction);
+            renderer.EnqueuePass(_copyPreRefractionColorPass);
+
+            if (!isPreviewCamera && !isOffscreenDepth)
+            {
+                if (useTransparentScreenSpaceReflection)
+                    renderer.EnqueuePass(_waterSSRDataPass);
+
+                // Clear the transparent reflection texture when screen space reflections are disabled.
+                renderer.EnqueuePass(_transparentScreenSpaceReflectionPass);
+            }
+
             // AfterRenderingTransparents
             if (orderIndependentTransparency)
             {
@@ -557,6 +602,10 @@ namespace Illusion.Rendering
             {
                 renderer.EnqueuePass(_stencilVRSDebugPass);
             }
+            if (config.EnableTransparentScreenSpaceReflectionDebug)
+            {
+                renderer.EnqueuePass(_transparentSSRDebugPass);
+            }
 #endif
             // AfterRenderingPostProcessing
             renderer.EnqueuePass(_processingPostPass);
@@ -565,6 +614,7 @@ namespace Illusion.Rendering
         private void PerformSetup(ContextContainer frameData, IllusionRendererData rendererData)
         {
             UpdateRenderDataSettings();
+            rendererData.TransparentScreenSpaceReflectionTexture = default;
             var cameraData = frameData.Get<UniversalCameraData>();
             var lightData = frameData.Get<UniversalLightData>();
             var shadowData = frameData.Get<UniversalShadowData>();
@@ -596,6 +646,11 @@ namespace Illusion.Rendering
                                             && screenSpaceReflection && !isPreviewOrReflectCamera
                                             && screenSpaceReflectionParam.enable.value;
             rendererData.SampleScreenSpaceReflection = useScreenSpaceReflection;
+            rendererData.SampleTransparentScreenSpaceReflection = useScreenSpaceReflection
+                                                                   && transparentScreenSpaceReflection
+                                                                   && config.EnableTransparentScreenSpaceReflection
+                                                                   && SystemInfo.supportsComputeShaders
+                                                                   && SystemInfo.graphicsDeviceType is not GraphicsDeviceType.OpenGLES3;
             rendererData.RequireHistoryDepthNormal = useScreenSpaceGlobalIllumination || useShadowTemporalAccumulation;
 
             var shadow = VolumeManager.instance.stack.GetComponent<PerObjectShadows>();
@@ -643,6 +698,9 @@ namespace Illusion.Rendering
             SafeDispose(ref _transparentCopyPreDepthPass);
             SafeDispose(ref _transparentCopyPostDepthPass);
             SafeDispose(ref _screenSpaceReflectionPass);
+            SafeDispose(ref _transparentScreenSpaceReflectionPass);
+            SafeDispose(ref _copyPreRefractionColorPass);
+            SafeDispose(ref _waterSSRDataPass);
             SafeDispose(ref _screenSpaceGlobalIlluminationPass);
             SafeDispose(ref _forwardGBufferPass);
             SafeDispose(ref _transparentStencilVRSPass);
@@ -661,6 +719,7 @@ namespace Illusion.Rendering
 
 #if DEVELOPMENT_BUILD || UNITY_EDITOR
             SafeDispose(ref _stencilVRSDebugPass);
+            SafeDispose(ref _transparentSSRDebugPass);
             SafeDispose(ref _motionVectorsDebugPass);
             SafeDispose(ref _exposureDebugPass);
 #endif

--- a/Runtime/RenderPipeline/IllusionRendererFeature.cs
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.cs
@@ -439,6 +439,8 @@ namespace Illusion.Rendering
             bool useTransparentOverdrawPass = orderIndependentTransparency && oitTransparentOverdrawPass && !isPreviewCamera;
 
             bool isOffscreenDepth = UniversalRenderingUtility.IsOffscreenDepthTexture(in renderingData.cameraData);
+            bool prepareTransparentDepth = useDepthPostPass
+                                           || (useTransparentScreenSpaceReflection && !isOffscreenDepth);
             bool useVrs = enableStencilVrs && ShadingRateInfo.supportsPerImageTile && config.EnableVrs;
 
             // Setup pass must run first
@@ -459,9 +461,13 @@ namespace Illusion.Rendering
             // BeforeRenderingPrePasses
             renderer.EnqueuePass(_advancedTonemappingPass);
 
-            if (useDepthPostPass)
+            if (prepareTransparentDepth)
             {
                 renderer.EnqueuePass(_transparentCopyPreDepthPass);
+            }
+
+            if (useDepthPostPass)
+            {
                 renderer.EnqueuePass(_transparentDepthOnlyPass);
             }
 

--- a/Runtime/RenderPipeline/IllusionRuntimeRenderingConfig.cs
+++ b/Runtime/RenderPipeline/IllusionRuntimeRenderingConfig.cs
@@ -19,6 +19,19 @@ namespace Illusion.Rendering
         /// </summary>
         [ConfigVariable("r.ssr")]
         public bool EnableScreenSpaceReflection { get; set; } = true;
+
+        /// <summary>
+        /// Whether enable Screen Space Reflection for transparent surfaces.
+        /// Requires Screen Space Reflection to be enabled.
+        /// </summary>
+        [ConfigVariable("r.ssr.transparent")]
+        public bool EnableTransparentScreenSpaceReflection { get; set; } = true;
+
+        /// <summary>
+        /// Whether enable Screen Space Refraction.
+        /// </summary>
+        [ConfigVariable("r.refraction")]
+        public bool EnableScreenSpaceRefraction { get; set; } = true;
         
         /// <summary>
         /// Whether enable Screen Space Reflection.
@@ -93,6 +106,9 @@ namespace Illusion.Rendering
         
         [ConfigVariable("r.debug.ssr", IsEditor = true)]
         public bool EnableScreenSpaceReflectionDebug { get; set; }
+
+        [ConfigVariable("r.debug.ssr.transparent", IsEditor = true)]
+        public bool EnableTransparentScreenSpaceReflectionDebug { get; set; }
         
         /// <summary>
         /// Exposure debug mode.

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/ScreenSpaceReflectionPass.cs
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/ScreenSpaceReflectionPass.cs
@@ -25,6 +25,8 @@ namespace Illusion.Rendering
 
         private readonly IllusionRendererData _rendererData;
 
+        private readonly bool _transparent;
+
         private readonly ComputeShader _computeShader;
 
         private readonly int _tracingKernel;
@@ -97,12 +99,17 @@ namespace Illusion.Rendering
             public float PBRBias;
 
             public int ColorPyramidMaxMip;
+            public int ReflectsSky;
+            public Vector2Int Padding;
         }
 
-        public ScreenSpaceReflectionPass(IllusionRendererData rendererData)
+        public ScreenSpaceReflectionPass(IllusionRendererData rendererData, bool transparent = false)
         {
             _rendererData = rendererData;
-            renderPassEvent = IllusionRenderPassEvent.ScreenSpaceReflectionPass;
+            _transparent = transparent;
+            renderPassEvent = transparent
+                ? IllusionRenderPassEvent.TransparentScreenSpaceReflectionPass
+                : IllusionRenderPassEvent.ScreenSpaceReflectionPass;
             _computeShader = rendererData.RuntimeResources.screenSpaceReflectionCS;
             _tracingKernel = _computeShader.FindKernel("ScreenSpaceReflectionCS");
             _reprojectionKernel = _computeShader.FindKernel("ScreenSpaceReflectionReprojectionCS");
@@ -122,17 +129,18 @@ namespace Illusion.Rendering
             var volume = VolumeManager.instance.stack.GetComponent<ScreenSpaceReflection>();
             _screenWidth = renderingData.cameraData.cameraTargetDescriptor.width;
             _screenHeight = renderingData.cameraData.cameraTargetDescriptor.height;
-            _isDownsampling = volume.DownSample.value;
+            _isDownsampling = !_transparent && volume.DownSample.value;
             int downsampleDivider = _isDownsampling ? 2 : 1;
             _rtWidth = _screenWidth / downsampleDivider;
             _rtHeight = _screenHeight / downsampleDivider;
             
             // @IllusionRP: Have not handled downsampling in compute shader yet.
-            _tracingInCS = volume.mode == ScreenSpaceReflectionMode.HizSS 
-                           && _rendererData.PreferComputeShader;
+            _tracingInCS = _transparent
+                ? _rendererData.PreferComputeShader
+                : volume.mode == ScreenSpaceReflectionMode.HizSS && _rendererData.PreferComputeShader;
             _reprojectInCS = _tracingInCS;
             // Skip accumulation in scene view
-            _needAccumulate = _reprojectInCS && renderingData.cameraData.cameraType == CameraType.Game
+            _needAccumulate = !_transparent && _reprojectInCS && renderingData.cameraData.cameraType == CameraType.Game
                                              && volume.usedAlgorithm.value == ScreenSpaceReflectionAlgorithm.PBRAccumulation;
             
             ref var ssrState = ref _rendererData.CurrentScreenSpaceReflectionHistoryState;
@@ -140,7 +148,8 @@ namespace Illusion.Rendering
                                       && (ssrState.CurrentAlgorithm == ScreenSpaceReflectionAlgorithm.Approximation
                                           || _rendererData.IsFirstFrame
                                           || _rendererData.ResetPostProcessingHistory);
-            ssrState.CurrentAlgorithm = volume.usedAlgorithm.value; // Store for next frame comparison
+            if (!_transparent)
+                ssrState.CurrentAlgorithm = volume.usedAlgorithm.value; // Store for next frame comparison
 
             // ================================ Allocation ================================ //
             _targetDescriptor = renderingData.cameraData.cameraTargetDescriptor;
@@ -151,7 +160,7 @@ namespace Illusion.Rendering
             _targetDescriptor.height = Mathf.CeilToInt(_rtHeight);
             _targetDescriptor.enableRandomWrite = _tracingInCS;
             
-            if (_needAccumulate || useRenderGraph)
+            if (!_transparent && (_needAccumulate || useRenderGraph))
             {
                 bool accumulationHistoryReallocated =
                     AllocateScreenSpaceAccumulationHistoryBuffer(_isDownsampling ? 0.5f : 1.0f);
@@ -203,6 +212,8 @@ namespace Illusion.Rendering
             _variables.EdgeFadeRcpLength = edgeFadeRcpLength;
             _variables.DepthPyramidMaxMip = _rendererData.DepthMipChainInfo.mipLevelCount - 1;
             _variables.ColorPyramidMaxMip = _rendererData.ColorPyramidHistoryMipCount - 1;
+            _variables.ReflectsSky = _transparent ? 0 : 1;
+            _variables.Padding = Vector2Int.zero;
             _variables.DownsamplingDivider = 1.0f / downsampleDivider;
             _variables.ProjectionMatrix = SSR_ProjectToPixelMatrix;
             
@@ -239,6 +250,7 @@ namespace Illusion.Rendering
             propertyBlock.SetFloat(Properties.SsrEdgeFadeRcpLength, variables.EdgeFadeRcpLength);
             propertyBlock.SetInteger(Properties.SsrDepthPyramidMaxMip, variables.DepthPyramidMaxMip);
             propertyBlock.SetInteger(Properties.SsrColorPyramidMaxMip, variables.ColorPyramidMaxMip);
+            propertyBlock.SetInteger(Properties.SsrReflectsSky, variables.ReflectsSky);
             propertyBlock.SetFloat(Properties.SsrDownsamplingDivider, variables.DownsamplingDivider);
             propertyBlock.SetMatrix(Properties.SsrProjectionMatrix, variables.ProjectionMatrix);
         }
@@ -265,7 +277,9 @@ namespace Illusion.Rendering
 
         private bool IsSSREnabled(ContextContainer frameData)
         {
-            if (!_rendererData.SampleScreenSpaceReflection)
+            if (_transparent
+                ? !_rendererData.SampleTransparentScreenSpaceReflection
+                : !_rendererData.SampleScreenSpaceReflection)
             {
                 return false;
             }
@@ -354,6 +368,7 @@ namespace Illusion.Rendering
             public bool UseAsync;
             public bool PreviousAccumNeedClear;
             public bool ValidColorPyramid;
+            public bool Transparent;
             
             // Clear resources
             public ComputeShader ClearBuffer2DCS;
@@ -362,6 +377,7 @@ namespace Illusion.Rendering
             // Texture handles
             public TextureHandle HitPointTexture;
             public TextureHandle DepthStencilTexture;
+            public TextureHandle SourceDepthTexture;
             public TextureHandle NormalTexture;
             public TextureHandle DepthPyramidTexture;
             public TextureHandle ColorPyramidTexture;
@@ -585,11 +601,12 @@ namespace Illusion.Rendering
         }
         
         private TextureHandle RenderSSRComputePass(RenderGraph renderGraph, TextureHandle hitPointTexture,
-            TextureHandle depthStencilTexture, TextureHandle normalTexture, TextureHandle depthPyramidTexture,
+            TextureHandle depthStencilTexture, TextureHandle sourceDepthTexture, TextureHandle normalTexture, TextureHandle depthPyramidTexture,
             TextureHandle colorPyramidTexture, TextureHandle motionVectorTexture, TextureHandle ssrAccum, 
             TextureHandle ssrAccumPrev, bool useAsyncCompute, bool isNewFrame)
         {
-            using (var builder = renderGraph.AddComputePass<CombinedSSRPassData>("Render SSR", out var passData))
+            using (var builder = renderGraph.AddComputePass<CombinedSSRPassData>(
+                       _transparent ? "Render Transparent SSR" : "Render SSR", out var passData))
             {
                 builder.EnableAsyncCompute(useAsyncCompute);
                 
@@ -642,6 +659,7 @@ namespace Illusion.Rendering
                 passData.UseAsync = useAsyncCompute;
                 passData.PreviousAccumNeedClear = _previousAccumNeedClear;
                 passData.ValidColorPyramid = isNewFrame;
+                passData.Transparent = _transparent;
                 
                 // Clear resources
                 passData.ClearBuffer2DCS = _clearBuffer2DCS;
@@ -652,6 +670,8 @@ namespace Illusion.Rendering
                 passData.HitPointTexture = hitPointTexture;
                 builder.UseTexture(depthStencilTexture);
                 passData.DepthStencilTexture = depthStencilTexture;
+                builder.UseTexture(sourceDepthTexture);
+                passData.SourceDepthTexture = sourceDepthTexture;
                 builder.UseTexture(normalTexture);
                 passData.NormalTexture = normalTexture;
                 builder.UseTexture(depthPyramidTexture);
@@ -687,6 +707,8 @@ namespace Illusion.Rendering
                     IllusionRendererData.BindDitheredTextureSet(ctx.cmd, data.BlueNoiseResources);
                     
                     CoreUtils.SetKeyword(ctx.cmd, "SSR_APPROX", !data.UsePBRAlgo);
+                    CoreUtils.SetKeyword(ctx.cmd, "DEPTH_SOURCE_NOT_FROM_MIP_CHAIN", data.Transparent);
+                    CoreUtils.SetKeyword(ctx.cmd, "TRANSPARENT_SSR", data.Transparent);
                     
                     // Clear operations
                     if (data.UsePBRAlgo || data.UseAsync)
@@ -716,6 +738,13 @@ namespace Illusion.Rendering
                             data.DepthStencilTexture, 0, RenderTextureSubElement.Stencil);
                         ctx.cmd.SetComputeTextureParam(cs, data.TracingKernel,
                             IllusionShaderProperties._CameraNormalsTexture, data.NormalTexture);
+                        if (data.Transparent)
+                        {
+                            ctx.cmd.SetComputeTextureParam(cs, data.TracingKernel, IllusionShaderProperties._DepthTexture,
+                                data.SourceDepthTexture, 0, RenderTextureSubElement.Depth);
+                            ctx.cmd.SetComputeTextureParam(cs, data.TracingKernel,
+                                IllusionShaderProperties._WaterSSRNormalTexture, data.NormalTexture);
+                        }
                         ctx.cmd.SetComputeTextureParam(cs, data.TracingKernel, Properties.SsrHitPointTexture,
                             data.HitPointTexture);
 
@@ -731,6 +760,13 @@ namespace Illusion.Rendering
                             IllusionShaderProperties._ColorPyramidTexture, data.ColorPyramidTexture);
                         ctx.cmd.SetComputeTextureParam(cs, data.ReprojectionKernel,
                             IllusionShaderProperties._CameraNormalsTexture, data.NormalTexture);
+                        if (data.Transparent)
+                        {
+                            ctx.cmd.SetComputeTextureParam(cs, data.ReprojectionKernel, IllusionShaderProperties._DepthTexture,
+                                data.SourceDepthTexture, 0, RenderTextureSubElement.Depth);
+                            ctx.cmd.SetComputeTextureParam(cs, data.ReprojectionKernel,
+                                IllusionShaderProperties._WaterSSRNormalTexture, data.NormalTexture);
+                        }
                         ctx.cmd.SetComputeTextureParam(cs, data.ReprojectionKernel, Properties.SsrHitPointTexture,
                             data.HitPointTexture);
                         ctx.cmd.SetComputeTextureParam(cs, data.ReprojectionKernel, Properties.SsrAccumTexture,
@@ -774,6 +810,12 @@ namespace Illusion.Rendering
         
         public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
         {
+            if (_transparent)
+            {
+                RecordTransparentRenderGraph(renderGraph, frameData);
+                return;
+            }
+
             var renderingData = new RenderingData(frameData);
             var resource = frameData.Get<UniversalResourceData>();
             
@@ -839,7 +881,7 @@ namespace Illusion.Rendering
                 var ssrAccumPrevRT = _rendererData.GetPreviousFrameRT((int)IllusionFrameHistoryType.ScreenSpaceReflectionAccumulation);
                 TextureHandle ssrAccumPrev = renderGraph.ImportTexture(ssrAccumPrevRT);
                 
-                finalResult = RenderSSRComputePass(renderGraph, hitPointTexture, depthStencilTexture,
+                finalResult = RenderSSRComputePass(renderGraph, hitPointTexture, depthStencilTexture, depthStencilTexture,
                     normalTexture, depthPyramidTexture, colorPyramidTexture, motionVectorTexture,
                     ssrAccum, ssrAccumPrev, useAsyncCompute, isNewFrame);
             }
@@ -887,6 +929,75 @@ namespace Illusion.Rendering
             }
         }
 
+        private void RecordTransparentRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+        {
+            if (!IsSSREnabled(frameData)
+                || !_rendererData.PreferComputeShader
+                || _rendererData.WaterSSRNormalRT == null
+                || !_rendererData.WaterSSRNormalRT.IsValid()
+                || _rendererData.DepthPyramidRT == null
+                || !_rendererData.DepthPyramidRT.IsValid())
+            {
+                var black = renderGraph.ImportTexture(_rendererData.GetBlackTextureRT());
+                _rendererData.TransparentScreenSpaceReflectionTexture = black;
+                RenderGraphUtils.SetGlobalTexture(renderGraph, IllusionShaderProperties.SsrLightingTexture, black);
+                return;
+            }
+
+            var renderingData = new RenderingData(frameData);
+            var resources = frameData.Get<UniversalResourceData>();
+            if (!resources.activeDepthTexture.IsValid())
+            {
+                var black = renderGraph.ImportTexture(_rendererData.GetBlackTextureRT());
+                _rendererData.TransparentScreenSpaceReflectionTexture = black;
+                RenderGraphUtils.SetGlobalTexture(renderGraph, IllusionShaderProperties.SsrLightingTexture, black);
+                return;
+            }
+            PrepareSSRData(ref renderingData, true);
+            PrepareVariables(ref renderingData.cameraData);
+
+            var previousColorRT = _rendererData.GetPreviousFrameColorRT(frameData, out bool colorHistoryValid);
+            if (previousColorRT == null || !previousColorRT.IsValid())
+            {
+                var black = renderGraph.ImportTexture(_rendererData.GetBlackTextureRT());
+                _rendererData.TransparentScreenSpaceReflectionTexture = black;
+                RenderGraphUtils.SetGlobalTexture(renderGraph, IllusionShaderProperties.SsrLightingTexture, black);
+                return;
+            }
+
+            TextureHandle sourceDepth = resources.activeDepthTexture;
+            TextureHandle waterNormal = renderGraph.ImportTexture(_rendererData.WaterSSRNormalRT);
+            TextureHandle depthPyramid = renderGraph.ImportTexture(_rendererData.DepthPyramidRT);
+            TextureHandle previousColor = renderGraph.ImportTexture(previousColorRT);
+            TextureHandle motionVectors = colorHistoryValid
+                ? resources.motionVectorColor
+                : renderGraph.ImportTexture(_rendererData.GetBlackTextureRT());
+
+            TextureHandle hitPoint = renderGraph.CreateTexture(new TextureDesc(_rtWidth, _rtHeight)
+            {
+                colorFormat = GraphicsFormat.R16G16_UNorm,
+                clearBuffer = true,
+                clearColor = Color.clear,
+                enableRandomWrite = true,
+                name = "Transparent_SSR_Hit_Point_Texture"
+            });
+            TextureHandle lighting = renderGraph.CreateTexture(new TextureDesc(_rtWidth, _rtHeight)
+            {
+                colorFormat = GraphicsFormat.R16G16B16A16_SFloat,
+                clearBuffer = true,
+                clearColor = Color.clear,
+                enableRandomWrite = true,
+                name = "Transparent_SSR_Lighting_Texture"
+            });
+
+            TextureHandle result = RenderSSRComputePass(renderGraph, hitPoint, sourceDepth, sourceDepth,
+                waterNormal, depthPyramid, previousColor, motionVectors, lighting, default,
+                false, colorHistoryValid);
+
+            _rendererData.TransparentScreenSpaceReflectionTexture = result;
+            RenderGraphUtils.SetGlobalTexture(renderGraph, IllusionShaderProperties.SsrLightingTexture, result);
+        }
+
         public void Dispose()
         {
             _material.DestroyCache();
@@ -913,6 +1024,8 @@ namespace Illusion.Rendering
             public static readonly int SsrDepthPyramidMaxMip = Shader.PropertyToID("_SsrDepthPyramidMaxMip");
             
             public static readonly int SsrColorPyramidMaxMip = Shader.PropertyToID("_SsrColorPyramidMaxMip");
+
+            public static readonly int SsrReflectsSky = Shader.PropertyToID("_SsrReflectsSky");
 
             public static readonly int SsrRoughnessFadeEnd = Shader.PropertyToID("_SsrRoughnessFadeEnd");
 

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/ScreenSpaceReflectionPass.cs
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/ScreenSpaceReflectionPass.cs
@@ -413,8 +413,11 @@ namespace Illusion.Rendering
                 
                 builder.SetRenderAttachment(hitPointTexture, 0);
                 passData.HitPointTexture = hitPointTexture;
-                builder.UseTexture(depthStencilTexture);
-                passData.DepthStencilTexture = depthStencilTexture;
+                if (!_transparent)
+                {
+                    builder.UseTexture(depthStencilTexture);
+                    passData.DepthStencilTexture = depthStencilTexture;
+                }
                 builder.UseTexture(normalTexture);
                 passData.NormalTexture = normalTexture;
                 builder.UseTexture(depthPyramidTexture);
@@ -668,8 +671,11 @@ namespace Illusion.Rendering
                 // Texture handles
                 builder.UseTexture(hitPointTexture, AccessFlags.ReadWrite);
                 passData.HitPointTexture = hitPointTexture;
-                builder.UseTexture(depthStencilTexture);
-                passData.DepthStencilTexture = depthStencilTexture;
+                if (!_transparent)
+                {
+                    builder.UseTexture(depthStencilTexture);
+                    passData.DepthStencilTexture = depthStencilTexture;
+                }
                 builder.UseTexture(sourceDepthTexture);
                 passData.SourceDepthTexture = sourceDepthTexture;
                 builder.UseTexture(normalTexture);
@@ -734,8 +740,11 @@ namespace Illusion.Rendering
                     {
                         ctx.cmd.SetComputeBufferParam(cs, data.TracingKernel,
                             IllusionShaderProperties._DepthPyramidMipLevelOffsets, data.OffsetBuffer);
-                        ctx.cmd.SetComputeTextureParam(cs, data.TracingKernel, IllusionShaderProperties._StencilTexture,
-                            data.DepthStencilTexture, 0, RenderTextureSubElement.Stencil);
+                        if (!data.Transparent)
+                        {
+                            ctx.cmd.SetComputeTextureParam(cs, data.TracingKernel, IllusionShaderProperties._StencilTexture,
+                                data.DepthStencilTexture, 0, RenderTextureSubElement.Stencil);
+                        }
                         ctx.cmd.SetComputeTextureParam(cs, data.TracingKernel,
                             IllusionShaderProperties._CameraNormalsTexture, data.NormalTexture);
                         if (data.Transparent)
@@ -945,14 +954,22 @@ namespace Illusion.Rendering
             }
 
             var renderingData = new RenderingData(frameData);
-            var resources = frameData.Get<UniversalResourceData>();
-            if (!resources.activeDepthTexture.IsValid())
+            if (!frameData.Contains<TransparentDepthData>())
             {
                 var black = renderGraph.ImportTexture(_rendererData.GetBlackTextureRT());
                 _rendererData.TransparentScreenSpaceReflectionTexture = black;
                 RenderGraphUtils.SetGlobalTexture(renderGraph, IllusionShaderProperties.SsrLightingTexture, black);
                 return;
             }
+            var transparentDepthData = frameData.Get<TransparentDepthData>();
+            if (!transparentDepthData.PostDepthTexture.IsValid())
+            {
+                var black = renderGraph.ImportTexture(_rendererData.GetBlackTextureRT());
+                _rendererData.TransparentScreenSpaceReflectionTexture = black;
+                RenderGraphUtils.SetGlobalTexture(renderGraph, IllusionShaderProperties.SsrLightingTexture, black);
+                return;
+            }
+            var resources = frameData.Get<UniversalResourceData>();
             PrepareSSRData(ref renderingData, true);
             PrepareVariables(ref renderingData.cameraData);
 
@@ -965,7 +982,7 @@ namespace Illusion.Rendering
                 return;
             }
 
-            TextureHandle sourceDepth = resources.activeDepthTexture;
+            TextureHandle sourceDepth = transparentDepthData.PostDepthTexture;
             TextureHandle waterNormal = renderGraph.ImportTexture(_rendererData.WaterSSRNormalRT);
             TextureHandle depthPyramid = renderGraph.ImportTexture(_rendererData.DepthPyramidRT);
             TextureHandle previousColor = renderGraph.ImportTexture(previousColorRT);
@@ -990,7 +1007,7 @@ namespace Illusion.Rendering
                 name = "Transparent_SSR_Lighting_Texture"
             });
 
-            TextureHandle result = RenderSSRComputePass(renderGraph, hitPoint, sourceDepth, sourceDepth,
+            TextureHandle result = RenderSSRComputePass(renderGraph, hitPoint, default, sourceDepth,
                 waterNormal, depthPyramid, previousColor, motionVectors, lighting, default,
                 false, colorHistoryValid);
 

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/TransparentSSRDebugPass.cs
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/TransparentSSRDebugPass.cs
@@ -1,0 +1,53 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.RenderGraphModule;
+using UnityEngine.Rendering.Universal;
+
+namespace Illusion.Rendering
+{
+    internal sealed class TransparentSSRDebugPass : ScriptableRenderPass, IDisposable
+    {
+        private readonly IllusionRendererData _rendererData;
+        private readonly Material _copyMaterial;
+
+        private sealed class PassData
+        {
+            internal TextureHandle Source;
+            internal Material Material;
+        }
+
+        public TransparentSSRDebugPass(IllusionRendererData rendererData)
+        {
+            _rendererData = rendererData;
+            _copyMaterial = CoreUtils.CreateEngineMaterial("Hidden/Universal/CoreBlit");
+            renderPassEvent = IllusionRenderPassEvent.FullScreenDebugPass;
+            profilingSampler = new ProfilingSampler("Transparent SSR Debug");
+        }
+
+        public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+        {
+            var resources = frameData.Get<UniversalResourceData>();
+            TextureHandle source = _rendererData.TransparentScreenSpaceReflectionTexture;
+            if (!source.IsValid() || !resources.activeColorTexture.IsValid() || !_copyMaterial)
+                return;
+
+            using var builder = renderGraph.AddRasterRenderPass<PassData>(
+                "Transparent SSR Debug", out var passData, profilingSampler);
+            builder.UseTexture(source);
+            builder.SetRenderAttachment(resources.activeColorTexture, 0);
+            builder.AllowPassCulling(false);
+            passData.Source = source;
+            passData.Material = _copyMaterial;
+            builder.SetRenderFunc(static (PassData data, RasterGraphContext context) =>
+            {
+                Blitter.BlitTexture(context.cmd, data.Source, new Vector4(1, 1, 0, 0), data.Material, 0);
+            });
+        }
+
+        public void Dispose()
+        {
+            CoreUtils.Destroy(_copyMaterial);
+        }
+    }
+}

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/TransparentSSRDebugPass.cs.meta
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/TransparentSSRDebugPass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8626510248854dfc9a82ea6fa1669a65
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/WaterSSRDataPass.cs
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/WaterSSRDataPass.cs
@@ -30,20 +30,9 @@ namespace Illusion.Rendering
             profilingSampler = new ProfilingSampler("Water SSR Data");
             ConfigureInput(ScriptableRenderPassInput.Depth);
 
-            var stencilState = StencilState.defaultValue;
-            stencilState.enabled = true;
-            stencilState.readMask = (byte)IllusionStencilUsage.TraceReflectionRay;
-            stencilState.writeMask = (byte)IllusionStencilUsage.TraceReflectionRay;
-            stencilState.SetCompareFunction(CompareFunction.Always);
-            stencilState.SetPassOperation(StencilOp.Replace);
-            stencilState.SetFailOperation(StencilOp.Keep);
-            stencilState.SetZFailOperation(StencilOp.Keep);
-
-            _renderStateBlock = new RenderStateBlock(RenderStateMask.Depth | RenderStateMask.Stencil)
+            _renderStateBlock = new RenderStateBlock(RenderStateMask.Depth)
             {
-                depthState = new DepthState(true, CompareFunction.LessEqual),
-                stencilReference = (int)IllusionStencilUsage.TraceReflectionRay,
-                stencilState = stencilState
+                depthState = new DepthState(true, CompareFunction.LessEqual)
             };
         }
 
@@ -51,9 +40,7 @@ namespace Illusion.Rendering
         {
             var cameraData = frameData.Get<UniversalCameraData>();
             var renderingData = frameData.Get<UniversalRenderingData>();
-            var resources = frameData.Get<UniversalResourceData>();
-            if (!resources.activeDepthTexture.IsValid())
-                return;
+            var transparentDepthData = frameData.GetOrCreate<TransparentDepthData>();
 
             var colorDescriptor = cameraData.cameraTargetDescriptor;
             colorDescriptor.msaaSamples = 1;
@@ -72,6 +59,7 @@ namespace Illusion.Rendering
                        "Clear Water SSR Data", out var clearData, profilingSampler))
             {
                 builder.SetRenderAttachment(normal, 0, AccessFlags.Write);
+                builder.SetGlobalTextureAfterPass(normal, IllusionShaderProperties._WaterSSRNormalTexture);
                 builder.AllowPassCulling(false);
                 builder.SetRenderFunc(static (PassData data, RasterGraphContext context) =>
                 {
@@ -79,11 +67,15 @@ namespace Illusion.Rendering
                 });
             }
 
+            TextureHandle waterDepth = transparentDepthData.PostDepthTexture;
+            if (!waterDepth.IsValid())
+                return;
+
             using (var builder = renderGraph.AddRasterRenderPass<PassData>(
                        "Water SSR Data", out var passData, profilingSampler))
             {
                 builder.SetRenderAttachment(normal, 0, AccessFlags.Write);
-                builder.SetRenderAttachmentDepth(resources.activeDepthTexture, AccessFlags.ReadWrite);
+                builder.SetRenderAttachmentDepth(waterDepth, AccessFlags.ReadWrite);
 
                 SortingCriteria sorting = SortingCriteria.CommonTransparent;
                 DrawingSettings drawingSettings = UniversalRenderingUtility.CreateDrawingSettings(

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/WaterSSRDataPass.cs
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/WaterSSRDataPass.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.RenderGraphModule;
+using UnityEngine.Rendering.Universal;
+
+namespace Illusion.Rendering
+{
+    /// <summary>
+    /// Renders water surface data for screen space reflections.
+    /// </summary>
+    public sealed class WaterSSRDataPass : ScriptableRenderPass, IDisposable
+    {
+        private readonly IllusionRendererData _rendererData;
+        private readonly List<ShaderTagId> _shaderTagIds = new() { new ShaderTagId("WaterSSRData") };
+        private readonly FilteringSettings _filteringSettings = new(RenderQueueRange.transparent);
+        private readonly RenderStateBlock _renderStateBlock;
+
+        private sealed class PassData
+        {
+            internal RendererListHandle RendererList;
+        }
+
+        public WaterSSRDataPass(IllusionRendererData rendererData)
+        {
+            _rendererData = rendererData;
+            renderPassEvent = IllusionRenderPassEvent.WaterSSRDataPass;
+            profilingSampler = new ProfilingSampler("Water SSR Data");
+            ConfigureInput(ScriptableRenderPassInput.Depth);
+
+            var stencilState = StencilState.defaultValue;
+            stencilState.enabled = true;
+            stencilState.readMask = (byte)IllusionStencilUsage.TraceReflectionRay;
+            stencilState.writeMask = (byte)IllusionStencilUsage.TraceReflectionRay;
+            stencilState.SetCompareFunction(CompareFunction.Always);
+            stencilState.SetPassOperation(StencilOp.Replace);
+            stencilState.SetFailOperation(StencilOp.Keep);
+            stencilState.SetZFailOperation(StencilOp.Keep);
+
+            _renderStateBlock = new RenderStateBlock(RenderStateMask.Depth | RenderStateMask.Stencil)
+            {
+                depthState = new DepthState(true, CompareFunction.LessEqual),
+                stencilReference = (int)IllusionStencilUsage.TraceReflectionRay,
+                stencilState = stencilState
+            };
+        }
+
+        public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+        {
+            var cameraData = frameData.Get<UniversalCameraData>();
+            var renderingData = frameData.Get<UniversalRenderingData>();
+            var resources = frameData.Get<UniversalResourceData>();
+            if (!resources.activeDepthTexture.IsValid())
+                return;
+
+            var colorDescriptor = cameraData.cameraTargetDescriptor;
+            colorDescriptor.msaaSamples = 1;
+            colorDescriptor.depthBufferBits = 0;
+            colorDescriptor.depthStencilFormat = GraphicsFormat.None;
+            colorDescriptor.graphicsFormat = GraphicsFormat.R16G16B16A16_SFloat;
+            colorDescriptor.enableRandomWrite = false;
+            colorDescriptor.useMipMap = false;
+            colorDescriptor.autoGenerateMips = false;
+            RenderingUtils.ReAllocateHandleIfNeeded(ref _rendererData.WaterSSRNormalRT, colorDescriptor,
+                FilterMode.Point, TextureWrapMode.Clamp, name: "_WaterSSRNormalTexture");
+
+            TextureHandle normal = renderGraph.ImportTexture(_rendererData.WaterSSRNormalRT);
+
+            using (var builder = renderGraph.AddRasterRenderPass<PassData>(
+                       "Clear Water SSR Data", out var clearData, profilingSampler))
+            {
+                builder.SetRenderAttachment(normal, 0, AccessFlags.Write);
+                builder.AllowPassCulling(false);
+                builder.SetRenderFunc(static (PassData data, RasterGraphContext context) =>
+                {
+                    context.cmd.ClearRenderTarget(RTClearFlags.Color, Color.clear, 1.0f, 0);
+                });
+            }
+
+            using (var builder = renderGraph.AddRasterRenderPass<PassData>(
+                       "Water SSR Data", out var passData, profilingSampler))
+            {
+                builder.SetRenderAttachment(normal, 0, AccessFlags.Write);
+                builder.SetRenderAttachmentDepth(resources.activeDepthTexture, AccessFlags.ReadWrite);
+
+                SortingCriteria sorting = SortingCriteria.CommonTransparent;
+                DrawingSettings drawingSettings = UniversalRenderingUtility.CreateDrawingSettings(
+                    _shaderTagIds, frameData, sorting);
+                RenderingUtils.CreateRendererListWithRenderStateBlock(renderGraph,
+                    ref renderingData.cullResults, drawingSettings, _filteringSettings,
+                    _renderStateBlock, ref passData.RendererList);
+                builder.UseRendererList(passData.RendererList);
+                builder.SetGlobalTextureAfterPass(normal, IllusionShaderProperties._WaterSSRNormalTexture);
+                builder.AllowPassCulling(false);
+                builder.AllowGlobalStateModification(true);
+
+                builder.SetRenderFunc(static (PassData data, RasterGraphContext context) =>
+                {
+                    context.cmd.DrawRendererList(data.RendererList);
+                });
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/WaterSSRDataPass.cs.meta
+++ b/Runtime/RenderPipeline/ScreenSpaceLighting/ScreenSpaceReflection/WaterSSRDataPass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fd6a0dbd9cc4b91990f7ee2ac6289ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/RenderPipeline/Transparency/CopyPreRefractionColorPass.cs
+++ b/Runtime/RenderPipeline/Transparency/CopyPreRefractionColorPass.cs
@@ -39,6 +39,20 @@ namespace Illusion.Rendering
         {
             var resources = frameData.Get<UniversalResourceData>();
             var cameraData = frameData.Get<UniversalCameraData>();
+
+            TextureHandle preWaterDepth = resources.cameraDepthTexture;
+            if (frameData.Contains<TransparentDepthData>())
+            {
+                var transparentDepthData = frameData.Get<TransparentDepthData>();
+                if (transparentDepthData.PreDepthTexture.IsValid())
+                    preWaterDepth = transparentDepthData.PreDepthTexture;
+            }
+            if (preWaterDepth.IsValid())
+            {
+                RenderGraphUtils.SetGlobalTexture(renderGraph,
+                    IllusionShaderProperties._WaterPreDepthTexture, preWaterDepth);
+            }
+
             TextureHandle source = resources.activeColorTexture;
             if (!_enabled || !source.IsValid() || !_copyMaterial)
             {

--- a/Runtime/RenderPipeline/Transparency/CopyPreRefractionColorPass.cs
+++ b/Runtime/RenderPipeline/Transparency/CopyPreRefractionColorPass.cs
@@ -1,0 +1,83 @@
+using System;
+using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.RenderGraphModule;
+using UnityEngine.Rendering.Universal;
+
+namespace Illusion.Rendering
+{
+    /// <summary>
+    /// Copies the opaque scene color for screen-space refraction.
+    /// </summary>
+    public sealed class CopyPreRefractionColorPass : ScriptableRenderPass, IDisposable
+    {
+        private readonly IllusionRendererData _rendererData;
+        private readonly Material _copyMaterial;
+        private bool _enabled;
+
+        private sealed class PassData
+        {
+            internal TextureHandle Source;
+            internal Material CopyMaterial;
+        }
+
+        public CopyPreRefractionColorPass(IllusionRendererData rendererData)
+        {
+            _rendererData = rendererData;
+            _copyMaterial = CoreUtils.CreateEngineMaterial("Hidden/Universal/CoreBlit");
+            renderPassEvent = IllusionRenderPassEvent.CopyPreRefractionColorPass;
+            profilingSampler = new ProfilingSampler("Copy Pre-Refraction Color");
+        }
+
+        public void Setup(bool enabled)
+        {
+            _enabled = enabled;
+        }
+
+        public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
+        {
+            var resources = frameData.Get<UniversalResourceData>();
+            var cameraData = frameData.Get<UniversalCameraData>();
+            TextureHandle source = resources.activeColorTexture;
+            if (!_enabled || !source.IsValid() || !_copyMaterial)
+            {
+                TextureHandle black = renderGraph.ImportTexture(_rendererData.GetBlackTextureRT());
+                RenderGraphUtils.SetGlobalTexture(renderGraph,
+                    IllusionShaderProperties._PreRefractionColorTexture, black);
+                return;
+            }
+
+            var descriptor = cameraData.cameraTargetDescriptor;
+            descriptor.msaaSamples = 1;
+            descriptor.depthBufferBits = 0;
+            descriptor.depthStencilFormat = GraphicsFormat.None;
+            descriptor.useMipMap = false;
+            descriptor.autoGenerateMips = false;
+            descriptor.enableRandomWrite = false;
+
+            RenderingUtils.ReAllocateHandleIfNeeded(ref _rendererData.PreRefractionColorRT, descriptor,
+                FilterMode.Bilinear, TextureWrapMode.Clamp, name: "_PreRefractionColorTexture");
+            TextureHandle destination = renderGraph.ImportTexture(_rendererData.PreRefractionColorRT);
+
+            using var builder = renderGraph.AddRasterRenderPass<PassData>(
+                "Copy Pre-Refraction Color", out var passData, profilingSampler);
+            builder.UseTexture(source);
+            builder.SetRenderAttachment(destination, 0);
+            builder.SetGlobalTextureAfterPass(destination, IllusionShaderProperties._PreRefractionColorTexture);
+            builder.AllowPassCulling(false);
+
+            passData.Source = source;
+            passData.CopyMaterial = _copyMaterial;
+            builder.SetRenderFunc(static (PassData data, RasterGraphContext context) =>
+            {
+                Blitter.BlitTexture(context.cmd, data.Source, new Vector4(1, 1, 0, 0), data.CopyMaterial, 0);
+            });
+        }
+
+        public void Dispose()
+        {
+            CoreUtils.Destroy(_copyMaterial);
+        }
+    }
+}

--- a/Runtime/RenderPipeline/Transparency/CopyPreRefractionColorPass.cs.meta
+++ b/Runtime/RenderPipeline/Transparency/CopyPreRefractionColorPass.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b3c8b8429de42e28bc145911362bf4c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ShaderLibrary/EvaluateScreenSpaceReflection.hlsl
+++ b/ShaderLibrary/EvaluateScreenSpaceReflection.hlsl
@@ -6,17 +6,16 @@
 #ifndef _SCREEN_SPACE_REFLECTION
     #define _SCREEN_SPACE_REFLECTION 0
 #endif
-
 #define TRANSPARENT_RECEIVE_SSR   (defined(_SURFACE_TYPE_TRANSPARENT) && defined(_TRANSPARENT_WRITE_DEPTH))
 
 #define SURFACE_TYPE_RECEIVE_SSR  (!defined(_SURFACE_TYPE_TRANSPARENT) || TRANSPARENT_RECEIVE_SSR)
 
-TEXTURE2D(_SsrLightingTexture);
+TEXTURE2D_X(_SsrLightingTexture);
 
 half4 SampleScreenSpaceReflection(float2 normalizedScreenSpaceUV) 
 {
     float2 positionSS = normalizedScreenSpaceUV * _ScreenSize.xy;
-    float4 ssrLighting = LOAD_TEXTURE2D(_SsrLightingTexture, positionSS);
+    float4 ssrLighting = LOAD_TEXTURE2D_X(_SsrLightingTexture, positionSS);
     ssrLighting.rgb *= GetInverseCurrentExposureMultiplier();
     return ssrLighting;
 }

--- a/Shaders/ScreenSpaceLighting/ScreenSpaceReflection.compute
+++ b/Shaders/ScreenSpaceLighting/ScreenSpaceReflection.compute
@@ -30,6 +30,8 @@
 #pragma multi_compile _ _GBUFFER_NORMALS_OCT
 #pragma multi_compile _ _DEFERRED_RENDERING_PATH
 #pragma multi_compile _ SSR_APPROX
+#pragma multi_compile _ DEPTH_SOURCE_NOT_FROM_MIP_CHAIN
+#pragma multi_compile _ TRANSPARENT_SSR
 
 #if defined(SSR_REPROJECT) || defined(SSR_ACCUMULATE)
     #include "Packages/com.kurisu.illusion-render-pipelines/ShaderLibrary/DeclareMotionVectorTexture.hlsl"
@@ -71,7 +73,7 @@ void MAIN_ACC(uint3 dispatchThreadId : SV_DispatchThreadID)
     uint2 positionSS = dispatchThreadId.xy;
     float3 N;
     float perceptualRoughness0;
-    GetNormalAndPerceptualRoughness(positionSS, N, perceptualRoughness0);
+    GetSSRNormalAndPerceptualRoughness(positionSS, N, perceptualRoughness0);
 
     // Compute the actual roughness
     float roughness = PerceptualRoughnessToRoughness(perceptualRoughness0);

--- a/Shaders/ScreenSpaceLighting/ScreenSpaceReflection.compute
+++ b/Shaders/ScreenSpaceLighting/ScreenSpaceReflection.compute
@@ -74,6 +74,13 @@ void MAIN_ACC(uint3 dispatchThreadId : SV_DispatchThreadID)
     float3 N;
     float perceptualRoughness0;
     GetSSRNormalAndPerceptualRoughness(positionSS, N, perceptualRoughness0);
+#ifdef TRANSPARENT_SSR
+    if (dot(N, N) <= 1e-4f)
+    {
+        _SsrAccumTexture[COORD_TEXTURE2D_X(positionSS)] = 0;
+        return;
+    }
+#endif
 
     // Compute the actual roughness
     float roughness = PerceptualRoughnessToRoughness(perceptualRoughness0);

--- a/Shaders/ScreenSpaceLighting/ScreenSpaceReflectionCommon.hlsl
+++ b/Shaders/ScreenSpaceLighting/ScreenSpaceReflectionCommon.hlsl
@@ -20,7 +20,9 @@
 #include "Packages/com.kurisu.illusion-render-pipelines/ShaderLibrary/NormalBuffer.hlsl"
 
 TEXTURE2D_X(_CameraDepthTexture); // Not used in Hiz version
+#ifndef TRANSPARENT_SSR
 TEXTURE2D_X_UINT2(_StencilTexture);
+#endif
 
 #ifdef DEPTH_SOURCE_NOT_FROM_MIP_CHAIN
 TEXTURE2D_X(_DepthTexture);
@@ -28,6 +30,12 @@ TEXTURE2D_X(_DepthTexture);
 
 #ifdef TRANSPARENT_SSR
 TEXTURE2D_X(_WaterSSRNormalTexture);
+
+bool IsTransparentSSRSurface(uint2 positionSS)
+{
+    float3 waterNormal = LOAD_TEXTURE2D_X(_WaterSSRNormalTexture, positionSS).xyz;
+    return dot(waterNormal, waterNormal) > 1e-4f;
+}
 #endif
 
 #ifdef SSR_REPROJECT
@@ -87,6 +95,12 @@ void GetSSRNormalAndPerceptualRoughness(uint2 positionSS, out float3 normalWS, o
 {
 #ifdef TRANSPARENT_SSR
     float4 waterData = LOAD_TEXTURE2D_X(_WaterSSRNormalTexture, positionSS);
+    if (dot(waterData.xyz, waterData.xyz) <= 1e-4f)
+    {
+        normalWS = 0;
+        perceptualRoughness = 1;
+        return;
+    }
     normalWS = normalize(waterData.xyz);
     perceptualRoughness = 1.0 - saturate(waterData.w);
 #else
@@ -479,8 +493,12 @@ void GetHitInfos(uint2 positionSS, out float srcPerceptualRoughness, out float3 
 // Ported from HDRP
 half4 ScreenSpaceReflection(uint2 positionSS)
 {
+#ifdef TRANSPARENT_SSR
+    if (!IsTransparentSSRSurface(positionSS))
+        return half4(0, 0, 0, 0);
+#else
     // TODO: Add stencil prepass in deferred rendering path
-#if !defined(_DEFERRED_RENDERING_PATH) || defined(TRANSPARENT_SSR)
+#if !defined(_DEFERRED_RENDERING_PATH)
     bool doesntReceiveSSR = false;
     uint stencilValue = GetStencilValue(LOAD_TEXTURE2D_X(_StencilTexture, positionSS.xy));
     doesntReceiveSSR = (stencilValue & STENCIL_USAGE_IS_SSR) == 0;
@@ -488,6 +506,7 @@ half4 ScreenSpaceReflection(uint2 positionSS)
     {
         return half4(0, 0, 0, 0);
     }
+#endif
 #endif
 
     float deviceDepth = GetDepthSample(positionSS);
@@ -760,6 +779,10 @@ float4 ScreenSpaceReflectionReprojection(uint2 positionSS0)
     float3 N;
     float perceptualRoughness;
     GetSSRNormalAndPerceptualRoughness(positionSS0, N, perceptualRoughness);
+#ifdef TRANSPARENT_SSR
+    if (dot(N, N) <= 1e-4f)
+        return 0;
+#endif
 
     // Compute the actual roughness
     // float roughness = PerceptualRoughnessToRoughness(perceptualRoughness);

--- a/Shaders/ScreenSpaceLighting/ScreenSpaceReflectionCommon.hlsl
+++ b/Shaders/ScreenSpaceLighting/ScreenSpaceReflectionCommon.hlsl
@@ -22,6 +22,14 @@
 TEXTURE2D_X(_CameraDepthTexture); // Not used in Hiz version
 TEXTURE2D_X_UINT2(_StencilTexture);
 
+#ifdef DEPTH_SOURCE_NOT_FROM_MIP_CHAIN
+TEXTURE2D_X(_DepthTexture);
+#endif
+
+#ifdef TRANSPARENT_SSR
+TEXTURE2D_X(_WaterSSRNormalTexture);
+#endif
+
 #ifdef SSR_REPROJECT
     TEXTURE2D_X(_SsrHitPointTexture);
     TEXTURE2D_X(_ColorPyramidTexture);
@@ -46,7 +54,6 @@ static half dither[16] = {
 
 /// ================== Hiz ================= //
 #define SSR_STEPS                   _Steps
-#define _SsrReflectsSky             1            // Should disable in transparent objects
 #ifndef SSR_APPROX
     #define SAMPLES_VNDF            1
 #endif
@@ -69,7 +76,22 @@ static half dither[16] = {
 
 float GetDepthSample(float2 positionSS)
 {
+#ifdef DEPTH_SOURCE_NOT_FROM_MIP_CHAIN
+    return LOAD_TEXTURE2D_X(_DepthTexture, positionSS).r;
+#else
     return LOAD_TEXTURE2D_X(_DepthPyramid, positionSS).r;
+#endif
+}
+
+void GetSSRNormalAndPerceptualRoughness(uint2 positionSS, out float3 normalWS, out float perceptualRoughness)
+{
+#ifdef TRANSPARENT_SSR
+    float4 waterData = LOAD_TEXTURE2D_X(_WaterSSRNormalTexture, positionSS);
+    normalWS = normalize(waterData.xyz);
+    perceptualRoughness = 1.0 - saturate(waterData.w);
+#else
+    GetNormalAndPerceptualRoughness(positionSS, normalWS, perceptualRoughness);
+#endif
 }
 
 float4 TransformViewToHScreen(float3 vpos, float2 screenSize)
@@ -415,7 +437,7 @@ void GetHitInfos(uint2 positionSS, out float srcPerceptualRoughness, out float3 
     Xi.y = GetBNDSequenceSample(positionSS, _FrameCount, 1);
     
     float perceptualRoughness;
-    GetNormalAndPerceptualRoughness(positionSS, N, perceptualRoughness);
+    GetSSRNormalAndPerceptualRoughness(positionSS, N, perceptualRoughness);
 
     srcPerceptualRoughness = perceptualRoughness;
 
@@ -458,7 +480,7 @@ void GetHitInfos(uint2 positionSS, out float srcPerceptualRoughness, out float3 
 half4 ScreenSpaceReflection(uint2 positionSS)
 {
     // TODO: Add stencil prepass in deferred rendering path
-#ifndef _DEFERRED_RENDERING_PATH
+#if !defined(_DEFERRED_RENDERING_PATH) || defined(TRANSPARENT_SSR)
     bool doesntReceiveSSR = false;
     uint stencilValue = GetStencilValue(LOAD_TEXTURE2D_X(_StencilTexture, positionSS.xy));
     doesntReceiveSSR = (stencilValue & STENCIL_USAGE_IS_SSR) == 0;
@@ -473,7 +495,7 @@ half4 ScreenSpaceReflection(uint2 positionSS)
 #ifdef SSR_APPROX
     float3 N;
     float perceptualRoughness;
-    GetNormalAndPerceptualRoughness(positionSS, N, perceptualRoughness);
+    GetSSRNormalAndPerceptualRoughness(positionSS, N, perceptualRoughness);
     float2 positionNDC = positionSS * _ScreenSize.zw + (0.5 * _ScreenSize.zw); // Should we precompute the half-texel bias? We seem to use it a lot.
     float3 positionWS = ComputeWorldSpacePosition(positionNDC, deviceDepth, SSR_MATRIX_I_VP); // Jittered
     float3 V = GetWorldSpaceNormalizeViewDir(positionWS);
@@ -720,7 +742,7 @@ float2 GetSampleInfo(uint2 positionSS, out float3 color, out float weight, out f
 
     float3 N;
     float perceptualRoughness;
-    GetNormalAndPerceptualRoughness(positionSS, N, perceptualRoughness);
+    GetSSRNormalAndPerceptualRoughness(positionSS, N, perceptualRoughness);
 
     float roughness = PerceptualRoughnessToRoughness(perceptualRoughness);
 
@@ -737,7 +759,7 @@ float4 ScreenSpaceReflectionReprojection(uint2 positionSS0)
 {
     float3 N;
     float perceptualRoughness;
-    GetNormalAndPerceptualRoughness(positionSS0, N, perceptualRoughness);
+    GetSSRNormalAndPerceptualRoughness(positionSS0, N, perceptualRoughness);
 
     // Compute the actual roughness
     // float roughness = PerceptualRoughnessToRoughness(perceptualRoughness);

--- a/Shaders/ScreenSpaceLighting/ShaderVariablesScreenSpaceReflection.hlsl
+++ b/Shaders/ScreenSpaceLighting/ShaderVariablesScreenSpaceReflection.hlsl
@@ -26,6 +26,8 @@ CBUFFER_START(ShaderVariablesScreenSpaceReflection)
     float _SsrPBRBias;
 
     int _SsrColorPyramidMaxMip;
+    int _SsrReflectsSky;
+    int2 _SsrVariablesPadding;
 CBUFFER_END
 
 #endif

--- a/Shaders/Water/Water Template.shader
+++ b/Shaders/Water/Water Template.shader
@@ -1,0 +1,3430 @@
+Shader /*ase_name*/ "Hidden/Universal/Water" /*end*/
+{
+	Properties
+	{
+		/*ase_props*/
+
+		//_TransmissionShadow( "Transmission Shadow", Range( 0, 1 ) ) = 0.5
+		//_TransStrength( "Trans Strength", Range( 0, 50 ) ) = 1
+		//_TransNormal( "Trans Normal Distortion", Range( 0, 1 ) ) = 0.5
+		//_TransScattering( "Trans Scattering", Range( 1, 50 ) ) = 2
+		//_TransDirect( "Trans Direct", Range( 0, 1 ) ) = 0.9
+		//_TransAmbient( "Trans Ambient", Range( 0, 1 ) ) = 0.1
+		//_TransShadow( "Trans Shadow", Range( 0, 1 ) ) = 0.5
+
+		//_TessPhongStrength( "Tess Phong Strength", Range( 0, 1 ) ) = 0.5
+		//_TessValue( "Tess Max Tessellation", Range( 1, 32 ) ) = 16
+		//_TessMin( "Tess Min Distance", Float ) = 10
+		//_TessMax( "Tess Max Distance", Float ) = 25
+		//_TessEdgeLength ( "Tess Edge length", Range( 2, 50 ) ) = 16
+		//_TessMaxDisp( "Tess Max Displacement", Float ) = 25
+
+		//_InstancedTerrainNormals("Instanced Terrain Normals", Float) = 1.0
+
+		[ToggleOff(_SPECULARHIGHLIGHTS_OFF)] _SpecularHighlights("Specular Highlights", Float) = 1.0
+		[ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
+		[ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
+		[WaterReflectionMode] _WaterReflectionMode("Water Reflection Mode", Float) = 0
+
+        // WaterSSRData
+        [HideInInspector] _StencilRefDepth("_StencilRefDepth", Int) = 4 // IllusionStencilUsage.TraceReflectionRay
+		[HideInInspector] _StencilWriteMaskDepth("_StencilWriteMaskDepth", Int) = 5 // IllusionStencilUsage.ForwardGBufferWriteMask
+
+		[HideInInspector] _QueueOffset("_QueueOffset", Float) = 0
+        [HideInInspector] _QueueControl("_QueueControl", Float) = -1
+
+        [HideInInspector][NoScaleOffset] unity_Lightmaps("unity_Lightmaps", 2DArray) = "" {}
+        [HideInInspector][NoScaleOffset] unity_LightmapsInd("unity_LightmapsInd", 2DArray) = "" {}
+        [HideInInspector][NoScaleOffset] unity_ShadowMasks("unity_ShadowMasks", 2DArray) = "" {}
+
+		[HideInInspector][ToggleUI] _AddPrecomputedVelocity("Add Precomputed Velocity", Float) = 1
+
+		[HideInInspector] _XRMotionVectorsPass("_XRMotionVectorsPass", Float) = 1
+	}
+
+	SubShader
+	{
+		/*ase_subshader_options:Name=Additional Options
+			Option:Category,InvertActionOnDeselection:Geometry,Terrain,Impostor:Geometry
+				Geometry:SetDefine:ASE_GEOMETRY
+				Terrain:SetDefine:ASE_TERRAIN
+				Terrain:ShowOption:  Instanced Terrain Normals
+				Terrain:SetPropertyOnPass:ScenePickingPass:ChangeTagValue,LightMode,Picking
+				Impostor:SetDefine:ASE_IMPOSTOR
+				Geometry,Impostor:SetPropertyOnPass:ScenePickingPass:ChangeTagValue,LightMode,ScenePickingPass
+			Option:  Instanced Terrain Normals,InvertActionOnDeselection:Force Vertex,Force Pixel,Material Option:Force Pixel
+				Force Vertex?Category=Terrain:SetShaderProperty:_InstancedTerrainNormals,//[KeywordEnum(Vertex, Pixel)] _InstancedTerrainNormals("Instanced Terrain Normals", Float) = 1.0
+				Force Pixel?Category=Terrain:SetDefine:_INSTANCEDTERRAINNORMALS_PIXEL
+				Force Pixel?Category=Terrain:SetShaderProperty:_InstancedTerrainNormals,//[KeywordEnum(Vertex, Pixel)] _InstancedTerrainNormals("Instanced Terrain Normals", Float) = 1.0
+				Material Option?Category=Terrain:SetDefine:Forward:pragma shader_feature _INSTANCEDTERRAINNORMALS_PIXEL
+				Material Option?Category=Terrain:SetDefine:GBuffer:pragma shader_feature _INSTANCEDTERRAINNORMALS_PIXEL
+				Material Option?Category=Terrain:SetDefine:WaterSSRData:pragma shader_feature _INSTANCEDTERRAINNORMALS_PIXEL
+				Material Option?Category=Terrain:SetShaderProperty:_InstancedTerrainNormals,[KeywordEnum(Vertex, Pixel)] _InstancedTerrainNormals("Instanced Terrain Normals", Float) = 1.0
+				disable:RemoveDefine:Forward:pragma shader_feature _INSTANCEDTERRAINNORMALS_PIXEL
+				disable:RemoveDefine:GBuffer:pragma shader_feature _INSTANCEDTERRAINNORMALS_PIXEL
+				disable:RemoveDefine:WaterSSRData:pragma shader_feature _INSTANCEDTERRAINNORMALS_PIXEL
+				disable:RemoveDefine:_INSTANCEDTERRAINNORMALS_PIXEL
+				disable:SetShaderProperty:_InstancedTerrainNormals,//[KeywordEnum(Vertex, Pixel)] _InstancedTerrainNormals("Instanced Terrain Normals", Float) = 1.0
+			Option:Lighting Model:PBR,Simple:PBR
+				PBR:SetPropertyOnSubShader:ChangeTagValue,UniversalMaterialType,Lit
+				PBR:RemoveDefine:ASE_LIGHTING_SIMPLE
+				PBR:ShowOption:Environment Reflections
+				PBR:SetShaderProperty:_EnvironmentReflections,[ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
+				Simple:SetOption:Workflow,0
+				Simple:SetDefine:ASE_LIGHTING_SIMPLE
+				Simple:SetPropertyOnSubShader:ChangeTagValue,UniversalMaterialType,SimpleLit
+				Simple,disable:HideOption:Environment Reflections
+				Simple:SetShaderProperty:_EnvironmentReflections,//[ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
+				Simple:RemoveDefine:Forward:pragma multi_compile_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+				Simple:RemoveDefine:GBuffer:pragma multi_compile_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+				Simple:RemoveDefine:Forward:pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+				Simple:RemoveDefine:GBuffer:pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+			Option:Workflow:Specular,Metallic:Metallic
+				Specular:SetDefine:_SPECULAR_SETUP 1
+				Specular:ShowPort:Forward:Specular
+				Specular:HidePort:Forward:Metallic
+				Metallic:SetOption:Lighting Model,0
+				Metallic:RemoveDefine:_SPECULAR_SETUP 1
+				Metallic:ShowPort:Forward:Metallic
+				Metallic:HidePort:Forward:Specular
+			Option:Surface:Opaque,Transparent:Opaque
+				Opaque:SetPropertyOnSubShader:RenderType,Opaque
+				Opaque:SetPropertyOnSubShader:RenderQueue,Geometry
+				Opaque:SetPropertyOnSubShader:ZWrite,On
+				Opaque:ExcludePass:WaterSSRData
+				Opaque:ShowOption:  Keep Alpha
+				Opaque:HideOption:  Refraction Model
+				Opaque:HideOption:  Blend
+				Opaque:RemoveDefine:_SURFACE_TYPE_TRANSPARENT 1
+				Opaque:RefreshOption:Alpha Clipping
+				Transparent:SetPropertyOnSubShader:RenderType,Transparent
+				Transparent:SetPropertyOnSubShader:RenderQueue,Transparent
+				Transparent:SetPropertyOnSubShader:ZWrite,Off
+				Transparent:IncludePass:WaterSSRData
+				Transparent:HideOption:  Keep Alpha
+				Transparent:ShowOption:  Refraction Model
+				Transparent:ShowOption:  Blend
+				Transparent:SetDefine:_SURFACE_TYPE_TRANSPARENT 1
+			Option:  Keep Alpha:false,true:false
+				true:SetDefine:ASE_OPAQUE_KEEP_ALPHA
+				false:RemoveDefine:ASE_OPAQUE_KEEP_ALPHA
+			Option:  Refraction Model:None,Legacy:None
+				None,disable:HidePort:Forward:Refraction Index
+				None,disable:HidePort:Forward:Refraction Color
+				None,disable:RemoveDefine:ASE_REFRACTION 1
+				None,disable:RemoveDefine:REQUIRE_OPAQUE_TEXTURE 1
+				Legacy:ShowPort:Forward:Refraction Index
+				Legacy:ShowPort:Forward:Refraction Color
+				Legacy:SetDefine:ASE_REFRACTION 1
+				Legacy:SetDefine:REQUIRE_OPAQUE_TEXTURE 1
+			Option:  Blend:Alpha,Premultiply,Additive,Multiply:Alpha
+				Alpha:SetPropertyOnPass:Forward:BlendRGB,SrcAlpha,OneMinusSrcAlpha
+				Premultiply:SetPropertyOnPass:Forward:BlendRGB,One,OneMinusSrcAlpha
+				Additive:SetPropertyOnPass:Forward:BlendRGB,One,One
+				Multiply:SetPropertyOnPass:Forward:BlendRGB,DstColor,Zero
+				Alpha,Premultiply,Additive:SetPropertyOnPass:Forward:BlendAlpha,One,OneMinusSrcAlpha
+				Multiply:SetPropertyOnPass:Forward:BlendAlpha,One,Zero
+				disable:SetPropertyOnPass:Forward:BlendRGB,One,Zero
+				disable:SetPropertyOnPass:Forward:BlendAlpha,One,Zero
+			Option:Two Sided:On,Cull Back,Cull Front:Cull Back
+				On:SetPropertyOnSubShader:CullMode,Off
+				Cull Back:SetPropertyOnSubShader:CullMode,Back
+				Cull Front:SetPropertyOnSubShader:CullMode,Front
+			Option:Alpha Clipping:false,true:true
+				true:ShowPort:Forward:Alpha Clip Threshold
+				true?Cast Shadows=true:ShowOption:  Use Shadow Threshold
+				true?Surface=Opaque:SetPropertyOnSubShader:RenderType,TransparentCutout
+				true?Surface=Opaque:SetPropertyOnSubShader:RenderQueue,AlphaTest
+				true:SetDefine:_ALPHATEST_ON
+				false:HidePort:Forward:Alpha Clip Threshold
+				false:SetOption:  Use Shadow Threshold,0
+				false:HideOption:  Use Shadow Threshold
+				false:RefreshOption:Surface
+				false:RemoveDefine:_ALPHATEST_ON
+			Option:  Use Shadow Threshold:false,true:false
+				true:ShowPort:Forward:Alpha Clip Threshold Shadow
+				true:SetDefine:_ALPHATEST_SHADOW_ON 1
+				false,disable:RemoveDefine:_ALPHATEST_SHADOW_ON 1
+				false,disable:HidePort:Forward:Alpha Clip Threshold Shadow
+			Option:Fragment Normal Space,InvertActionOnDeselection:Tangent,Object,World:Tangent
+				Tangent:SetDefine:_NORMAL_DROPOFF_TS 1
+				Tangent:SetPortName:Forward:1,Normal
+				Object:SetDefine:_NORMAL_DROPOFF_OS 1
+				Object:SetPortName:Forward:1,Object Normal
+				World:SetDefine:_NORMAL_DROPOFF_WS 1
+				World:SetPortName:Forward:1,World Normal
+			Option:Forward Only:false,true:false
+				false,disable:SetPropertyOnPass:Forward:ChangeTagValue,LightMode,UniversalForward
+				false,disable:IncludePass:GBuffer
+				true:SetPropertyOnPass:Forward:ChangeTagValue,LightMode,UniversalForwardOnly
+				true:ExcludePass:GBuffer
+			Option:Transmission:false,true:false
+				true:SetOption:Forward Only,1
+				true:ExcludePass:GBuffer
+				false,disable:IncludePass:GBuffer
+				false:RemoveDefine:ASE_TRANSMISSION 1
+				false:HidePort:Forward:Transmission
+				false:HideOption:  Transmission Shadow
+				true:SetDefine:ASE_TRANSMISSION 1
+				true:ShowPort:Forward:Transmission
+				true:ShowOption:  Transmission Shadow
+			Field:  Transmission Shadow:Float:0.5:0:1:_TransmissionShadow
+				Change:SetMaterialProperty:_TransmissionShadow
+				Change:SetShaderProperty:_TransmissionShadow,_TransmissionShadow( "Transmission Shadow", Range( 0, 1 ) ) = 0.5
+				Inline,disable:SetShaderProperty:_TransmissionShadow,//_TransmissionShadow( "Transmission Shadow", Range( 0, 1 ) ) = 0.5
+			Option:Translucency:false,true:false
+				true:SetOption:Forward Only,1
+				true:ExcludePass:GBuffer
+				false,disable:IncludePass:GBuffer
+				false:RemoveDefine:ASE_TRANSLUCENCY 1
+				false:HidePort:Forward:Translucency
+				false:HideOption:  Translucency Strength
+				false:HideOption:  Normal Distortion
+				false:HideOption:  Scattering
+				false:HideOption:  Direct
+				false:HideOption:  Ambient
+				false:HideOption:  Shadow
+				true:SetDefine:ASE_TRANSLUCENCY 1
+				true:ShowPort:Forward:Translucency
+				true:ShowOption:  Translucency Strength
+				true:ShowOption:  Normal Distortion
+				true:ShowOption:  Scattering
+				true:ShowOption:  Direct
+				true:ShowOption:  Ambient
+				true:ShowOption:  Shadow
+			Field:  Translucency Strength:Float:1:0:50:_TransStrength
+				Change:SetMaterialProperty:_TransStrength
+				Change:SetShaderProperty:_TransStrength,_TransStrength( "Strength", Range( 0, 50 ) ) = 1
+				Inline,disable:SetShaderProperty:_TransStrength,//_TransStrength( "Strength", Range( 0, 50 ) ) = 1
+			Field:  Normal Distortion:Float:0.5:0:1:_TransNormal
+				Change:SetMaterialProperty:_TransNormal
+				Change:SetShaderProperty:_TransNormal,_TransNormal( "Normal Distortion", Range( 0, 1 ) ) = 0.5
+				Inline,disable:SetShaderProperty:_TransNormal,//_TransNormal( "Normal Distortion", Range( 0, 1 ) ) = 0.5
+			Field:  Scattering:Float:2:1:50:_TransScattering
+				Change:SetMaterialProperty:_TransScattering
+				Change:SetShaderProperty:_TransScattering,_TransScattering( "Scattering", Range( 1, 50 ) ) = 2
+				Inline,disable:SetShaderProperty:_TransScattering,//_TransScattering( "Scattering", Range( 1, 50 ) ) = 2
+			Field:  Direct:Float:0.9:0:1:_TransDirect
+				Change:SetMaterialProperty:_TransDirect
+				Change:SetShaderProperty:_TransDirect,_TransDirect( "Direct", Range( 0, 1 ) ) = 0.9
+				Inline,disable:SetShaderProperty:_TransDirect,//_TransDirect( "Direct", Range( 0, 1 ) ) = 0.9
+			Field:  Ambient:Float:0.1:0:1:_TransAmbient
+				Change:SetMaterialProperty:_TransAmbient
+				Change:SetShaderProperty:_TransAmbient,_TransAmbient( "Ambient", Range( 0, 1 ) ) = 0.1
+				Inline,disable:SetShaderProperty:_TransAmbient,//_TransAmbient( "Ambient", Range( 0, 1 ) ) = 0.1
+			Field:  Shadow:Float:0.5:0:1:_TransShadow
+				Change:SetMaterialProperty:_TransShadow
+				Change:SetShaderProperty:_TransShadow,_TransShadow( "Shadow", Range( 0, 1 ) ) = 0.5
+				Inline,disable:SetShaderProperty:_TransShadow,//_TransShadow( "Shadow", Range( 0, 1 ) ) = 0.5
+			Option:Cast Shadows:false,true:true
+				true:IncludePass:ShadowCaster
+				false,disable:ExcludePass:ShadowCaster
+				true?Alpha Clipping=true:ShowOption:  Use Shadow Threshold
+				false:HideOption:  Use Shadow Threshold
+			Option:Receive Shadows:Force Off,Force On,Material Toggle:Material Toggle
+				Force On:RemoveDefine:_RECEIVE_SHADOWS_OFF
+				Force On:RemoveDefine:Forward:pragma shader_feature_local_fragment _RECEIVE_SHADOWS_OFF
+				Force On:RemoveDefine:GBuffer:pragma shader_feature_local_fragment _RECEIVE_SHADOWS_OFF
+				Force On:SetShaderProperty:_ReceiveShadows,//[ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
+				Force Off:RemoveDefine:Forward:pragma shader_feature_local_fragment _RECEIVE_SHADOWS_OFF
+				Force Off:RemoveDefine:GBuffer:pragma shader_feature_local_fragment _RECEIVE_SHADOWS_OFF
+				Force Off:SetDefine:_RECEIVE_SHADOWS_OFF
+				Force Off:SetShaderProperty:_ReceiveShadows,//[ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
+				Material Toggle:SetDefine:Forward:pragma shader_feature_local_fragment _RECEIVE_SHADOWS_OFF
+				Material Toggle:SetDefine:GBuffer:pragma shader_feature_local_fragment _RECEIVE_SHADOWS_OFF
+				Material Toggle:RemoveDefine:_RECEIVE_SHADOWS_OFF
+				Material Toggle:SetShaderProperty:_ReceiveShadows,[ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
+			Option:Specular Highlights:Force Off,Force On,Material Toggle:Material Toggle
+				Force On:RemoveDefine:_SPECULARHIGHLIGHTS_OFF
+				Force On:RemoveDefine:Forward:pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+				Force On:RemoveDefine:GBuffer:pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+				Force On:SetShaderProperty:_SpecularHighlights,//[ToggleOff(_SPECULARHIGHLIGHTS_OFF)] _SpecularHighlights("Specular Highlights", Float) = 1.0
+				Force Off:RemoveDefine:Forward:pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+				Force Off:RemoveDefine:GBuffer:pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+				Force Off:SetDefine:_SPECULARHIGHLIGHTS_OFF
+				Force Off:SetShaderProperty:_SpecularHighlights,//[ToggleOff(_SPECULARHIGHLIGHTS_OFF)] _SpecularHighlights("Specular Highlights", Float) = 1.0
+				Material Toggle:SetDefine:Forward:pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+				Material Toggle:SetDefine:GBuffer:pragma shader_feature_local_fragment _SPECULARHIGHLIGHTS_OFF
+				Material Toggle:RemoveDefine:_SPECULARHIGHLIGHTS_OFF
+				Material Toggle:SetShaderProperty:_SpecularHighlights,[ToggleOff(_SPECULARHIGHLIGHTS_OFF)] _SpecularHighlights("Specular Highlights", Float) = 1.0
+			Option:Environment Reflections:Force Off,Force On,Material Toggle:Material Toggle
+				Force On:RemoveDefine:_ENVIRONMENTREFLECTIONS_OFF
+				Force On:RemoveDefine:Forward:pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+				Force On:RemoveDefine:GBuffer:pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+				Force On:SetShaderProperty:_EnvironmentReflections,//[ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
+				Force Off:RemoveDefine:Forward:pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+				Force Off:RemoveDefine:GBuffer:pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+				Force Off:SetDefine:_ENVIRONMENTREFLECTIONS_OFF
+				Force Off:SetShaderProperty:_EnvironmentReflections,//[ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
+				Material Toggle:SetDefine:Forward:pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+				Material Toggle:SetDefine:GBuffer:pragma shader_feature_local_fragment _ENVIRONMENTREFLECTIONS_OFF
+				Material Toggle:RemoveDefine:_ENVIRONMENTREFLECTIONS_OFF
+				Material Toggle:SetShaderProperty:_EnvironmentReflections,[ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
+			Option:Receive SSAO:false,true:true
+				true:SetDefine:Forward:pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+				false:RemoveDefine:Forward:pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+			Option:Motion Vectors:false,true:true
+				true:ShowOption:  Add Precomputed Velocity
+				true:ShowOption:  XR Motion Vectors
+				true:IncludePass:MotionVectors
+				true:SetOption:Tessellation,0
+				false:HideOption:  Add Precomputed Velocity
+				false:HideOption:  XR Motion Vectors
+				false:ExcludePass:MotionVectors
+				false:ExcludePass:XRMotionVectors
+			Option:  Add Precomputed Velocity:false,true:false
+				true:SetShaderProperty:_AddPrecomputedVelocity,[HideInInspector][ToggleUI] _AddPrecomputedVelocity("Add Precomputed Velocity", Float) = 1
+				true:SetShaderProperty:_AddPrecomputedVelocity,1
+				true:SetDefine:MotionVectors:pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+				true:SetDefine:XRMotionVectors:pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+				false:SetShaderProperty:_AddPrecomputedVelocity,//[HideInInspector][ToggleUI] _AddPrecomputedVelocity("Add Precomputed Velocity", Float) = 1
+				false:RemoveDefine:MotionVectors:pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+				false:RemoveDefine:XRMotionVectors:pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+			Option:  XR Motion Vectors:false,true:false
+				true:IncludePass:XRMotionVectors
+				true:SetShaderProperty:_XRMotionVectorsPass,[HideInInspector] _XRMotionVectorsPass("_XRMotionVectorsPass", Float) = 1
+				false:ExcludePass:XRMotionVectors
+				false:SetShaderProperty:_XRMotionVectorsPass,//[HideInInspector] _XRMotionVectorsPass("_XRMotionVectorsPass", Float) = 1
+			Option:GPU Instancing:false,true:true
+				true:SetDefine:Forward:pragma multi_compile_instancing
+				true:SetDefine:GBuffer:pragma multi_compile_instancing
+				true:SetDefine:WaterSSRData:pragma multi_compile_instancing
+				true:SetDefine:ShadowCaster:pragma multi_compile_instancing
+				true:SetDefine:DepthOnly:pragma multi_compile_instancing
+				false:RemoveDefine:Forward:pragma multi_compile_instancing
+				false:RemoveDefine:GBuffer:pragma multi_compile_instancing
+				false:RemoveDefine:WaterSSRData:pragma multi_compile_instancing
+				false:RemoveDefine:ShadowCaster:pragma multi_compile_instancing
+				false:RemoveDefine:DepthOnly:pragma multi_compile_instancing
+				true:SetDefine:Forward:pragma instancing_options renderinglayer
+				true:SetDefine:GBuffer:pragma instancing_options renderinglayer
+				true:SetDefine:WaterSSRData:pragma instancing_options renderinglayer
+				false:RemoveDefine:Forward:pragma instancing_options renderinglayer
+				false:RemoveDefine:GBuffer:pragma instancing_options renderinglayer
+			Option:LOD CrossFade:false,true:true
+				true:SetDefine:Forward:pragma multi_compile _ LOD_FADE_CROSSFADE
+				true:SetDefine:GBuffer:pragma multi_compile _ LOD_FADE_CROSSFADE
+				true:SetDefine:WaterSSRData:pragma multi_compile _ LOD_FADE_CROSSFADE
+				true:SetDefine:ShadowCaster:pragma multi_compile _ LOD_FADE_CROSSFADE
+				true:SetDefine:DepthOnly:pragma multi_compile _ LOD_FADE_CROSSFADE
+				true:SetDefine:MotionVectors:pragma multi_compile _ LOD_FADE_CROSSFADE
+				true:SetDefine:XRMotionVectors:pragma multi_compile _ LOD_FADE_CROSSFADE
+				false:RemoveDefine:Forward:pragma multi_compile _ LOD_FADE_CROSSFADE
+				false:RemoveDefine:GBuffer:pragma multi_compile _ LOD_FADE_CROSSFADE
+				false:RemoveDefine:WaterSSRData:pragma multi_compile _ LOD_FADE_CROSSFADE
+				false:RemoveDefine:ShadowCaster:pragma multi_compile _ LOD_FADE_CROSSFADE
+				false:RemoveDefine:DepthOnly:pragma multi_compile _ LOD_FADE_CROSSFADE
+				false:RemoveDefine:MotionVectors:pragma multi_compile _ LOD_FADE_CROSSFADE
+				false:RemoveDefine:XRMotionVectors:pragma multi_compile _ LOD_FADE_CROSSFADE
+			Option:Built-in Fog:false,true:true
+				true:SetDefine:ASE_FOG 1
+				false:RemoveDefine:ASE_FOG 1
+			Option,_FinalColorxAlpha:Final Color x Alpha:true,false:false
+				true:SetDefine:ASE_FINAL_COLOR_ALPHA_MULTIPLY 1
+				false:RemoveDefine:ASE_FINAL_COLOR_ALPHA_MULTIPLY 1
+			Option:Meta Pass:false,true:true
+				true:IncludePass:Meta
+				false,disable:ExcludePass:Meta
+			Option:Override Baked GI:false,true:false
+				true:ShowPort:Forward:Baked GI
+				false:HidePort:Forward:Baked GI
+			Option:Tessellation:false,true:false
+				true:SetDefine:ASE_TESSELLATION 1
+				true:SetDefine:pragma require tessellation tessHW
+				true:SetDefine:pragma hull HullFunction
+				true:SetDefine:pragma domain DomainFunction
+				true:ShowOption:  Phong
+				true:ShowOption:  Type
+				false,disable:RemoveDefine:ASE_TESSELLATION 1
+				false,disable:RemoveDefine:pragma require tessellation tessHW
+				false,disable:RemoveDefine:pragma hull HullFunction
+				false,disable:RemoveDefine:pragma domain DomainFunction
+				false,disable:HideOption:  Phong
+				false,disable:HideOption:  Type
+				true:SetOption:Motion Vectors,0
+			Option:  Phong:false,true:false
+				true:SetDefine:ASE_PHONG_TESSELLATION
+				false,disable:RemoveDefine:ASE_PHONG_TESSELLATION
+				true:ShowOption:  Strength
+				false,disable:HideOption:  Strength
+			Field:  Strength:Float:0.5:0:1:_TessPhongStrength
+				Change:SetMaterialProperty:_TessPhongStrength
+				Change:SetShaderProperty:_TessPhongStrength,_TessPhongStrength( "Phong Tess Strength", Range( 0, 1 ) ) = 0.5
+				Inline,disable:SetShaderProperty:_TessPhongStrength,//_TessPhongStrength( "Phong Tess Strength", Range( 0, 1 ) ) = 0.5
+			Option:  Type:Fixed,Distance Based,Edge Length,Edge Length Cull:Fixed
+				Fixed:SetDefine:ASE_FIXED_TESSELLATION
+				Fixed,Distance Based:ShowOption:  Tess
+				Distance Based:SetDefine:ASE_DISTANCE_TESSELLATION
+				Distance Based:ShowOption:  Min
+				Distance Based:ShowOption:  Max
+				Edge Length:SetDefine:ASE_LENGTH_TESSELLATION
+				Edge Length,Edge Length Cull:ShowOption:  Edge Length
+				Edge Length Cull:SetDefine:ASE_LENGTH_CULL_TESSELLATION
+				Edge Length Cull:ShowOption:  Max Displacement
+				disable,Distance Based,Edge Length,Edge Length Cull:RemoveDefine:ASE_FIXED_TESSELLATION
+				disable,Fixed,Edge Length,Edge Length Cull:RemoveDefine:ASE_DISTANCE_TESSELLATION
+				disable,Fixed,Distance Based,Edge Length Cull:RemoveDefine:ASE_LENGTH_TESSELLATION
+				disable,Fixed,Distance Based,Edge Length:RemoveDefine:ASE_LENGTH_CULL_TESSELLATION
+				disable,Edge Length,Edge Length Cull:HideOption:  Tess
+				disable,Fixed,Edge Length,Edge Length Cull:HideOption:  Min
+				disable,Fixed,Edge Length,Edge Length Cull:HideOption:  Max
+				disable,Fixed,Distance Based:HideOption:  Edge Length
+				disable,Fixed,Distance Based,Edge Length:HideOption:  Max Displacement
+			Field:  Tess:Float:16:1:32:_TessValue
+				Change:SetMaterialProperty:_TessValue
+				Change:SetShaderProperty:_TessValue,_TessValue( "Max Tessellation", Range( 1, 32 ) ) = 16
+				Inline,disable:SetShaderProperty:_TessValue,//_TessValue( "Max Tessellation", Range( 1, 32 ) ) = 16
+			Field:  Min:Float:10:_TessMin
+				Change:SetMaterialProperty:_TessMin
+				Change:SetShaderProperty:_TessMin,_TessMin( "Tess Min Distance", Float ) = 10
+				Inline,disable:SetShaderProperty:_TessMin,//_TessMin( "Tess Min Distance", Float ) = 10
+			Field:  Max:Float:25:_TessMax
+				Change:SetMaterialProperty:_TessMax
+				Change:SetShaderProperty:_TessMax,_TessMax( "Tess Max Distance", Float ) = 25
+				Inline,disable:SetShaderProperty:_TessMax,//_TessMax( "Tess Max Distance", Float ) = 25
+			Field:  Edge Length:Float:16:2:50:_TessEdgeLength
+				Change:SetMaterialProperty:_TessEdgeLength
+				Change:SetShaderProperty:_TessEdgeLength,_TessEdgeLength ( "Edge length", Range( 2, 50 ) ) = 16
+				Inline,disable:SetShaderProperty:_TessEdgeLength,//_TessEdgeLength ( "Edge length", Range( 2, 50 ) ) = 16
+			Field:  Max Displacement:Float:25:_TessMaxDisp
+				Change:SetMaterialProperty:_TessMaxDisp
+				Change:SetShaderProperty:_TessMaxDisp,_TessMaxDisp( "Max Displacement", Float ) = 25
+				Inline,disable:SetShaderProperty:_TessMaxDisp,//_TessMaxDisp( "Max Displacement", Float ) = 25
+			Option:Write Depth:false,true:false
+				true:SetDefine:ASE_DEPTH_WRITE_ON
+				true:ShowOption:  Early Z
+				true:ShowPort:Forward:Depth
+				false,disable:RemoveDefine:ASE_DEPTH_WRITE_ON
+				false,disable:HideOption:  Early Z
+				false,disable:HidePort:Forward:Depth
+			Option:  Early Z:false,true:false
+				true:SetDefine:ASE_EARLY_Z_DEPTH_OPTIMIZE
+				false,disable:RemoveDefine:ASE_EARLY_Z_DEPTH_OPTIMIZE
+			Option:Vertex Position,InvertActionOnDeselection:Absolute,Relative:Relative
+				Absolute:SetDefine:ASE_ABSOLUTE_VERTEX_POS 1
+				Absolute:SetPortName:Forward:8,Vertex Position
+				Relative:SetPortName:Forward:8,Vertex Offset
+			Option:Debug Display:false,true:true
+				true:SetDefine:pragma multi_compile_fragment _ DEBUG_DISPLAY
+				false,disable:RemoveDefine:pragma multi_compile_fragment _ DEBUG_DISPLAY
+			Option:Clear Coat:false,true:false
+				true:ShowPort:Forward:Coat Mask
+				true:ShowPort:Forward:Coat Smoothness
+				true:SetDefine:Forward:shader_feature_local_fragment _ _CLEARCOAT
+				true:SetDefine:Forward:_CLEARCOAT 1
+				true:SetOption:Forward Only,1
+				true:ExcludePass:GBuffer
+				false,disable:HidePort:Forward:Coat Mask
+				false,disable:HidePort:Forward:Coat Smoothness
+				false:RemoveDefine:Forward:shader_feature_local_fragment _ _CLEARCOAT
+				false:RemoveDefine:Forward:_CLEARCOAT 1
+				false,disable:IncludePass:GBuffer
+			Port:Forward:Emission
+				On:SetDefine:_EMISSION
+			Port:Forward:Baked GI
+				On:SetDefine:ASE_BAKEDGI 1
+			Port:Forward:Normal
+				On:SetDefine:_NORMALMAP 1
+		*/
+
+		/*ase_unity_cond_begin:<=10000000*/
+			// A list of master node input port IDs; will be excluded from generated shaders.
+			//  0 => Frag: Base Color
+			//  1 => Frag: Normal
+			//  2 => Frag: Emission
+			//  3 => Frag: Metallic
+			//  4 => Frag: Smoothness
+			//  5 => Frag: Occlusion
+			//  6 => Frag: Alpha
+			//  7 => Frag: Alpha Clip Threshold
+			//  8 => Vert: Vertex Offset
+			//  9 => Frag: Specular
+			// 10 => Vert: Vertex Normal
+			// 11 => Frag: Baked GI
+			// 12 => Frag: Refraction Color
+			// 13 => Frag: Refraction Index
+			// 14 => Frag: Transmission
+			// 15 => Frag: Translucency
+			// 16 => Frag: Alpha Clip Threshold Shadow
+			// 17 => Frag: Depth Value
+			// 18 => Frag: Coat Mask
+			// 20 => Frag: Coat Smoothness
+			// 30 => Vert: Vertex Tangent
+		/*ase_unity_cond_end*/
+
+		Tags
+		{
+			"RenderPipeline" = "UniversalPipeline"
+			"RenderType"="Opaque"
+			"Queue"="Geometry+0"
+			"UniversalMaterialType"="Lit"
+		}
+
+		Cull Back
+		ZWrite On
+		ZTest LEqual
+		Offset 0,0
+		AlphaToMask Off
+
+		/*ase_stencil*/
+
+		HLSLINCLUDE
+		#pragma target 4.5
+		#pragma prefer_hlslcc gles
+		#pragma exclude_renderers d3d9 // ensure rendering platforms toggle list is visible
+
+		#if ( SHADER_TARGET > 35 ) && defined( SHADER_API_GLES3 )
+			#error For WebGL2/GLES3, please set your shader target to 3.5 via SubShader options. URP shaders in ASE use target 4.5 by default.
+		#endif
+
+		#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+		#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Filtering.hlsl"
+
+		#ifndef ASE_TESS_FUNCS
+		#define ASE_TESS_FUNCS
+		float4 FixedTess( float tessValue )
+		{
+			return tessValue;
+		}
+
+		float CalcDistanceTessFactor (float4 vertex, float minDist, float maxDist, float tess, float4x4 o2w, float3 cameraPos )
+		{
+			float3 wpos = mul(o2w,vertex).xyz;
+			float dist = distance (wpos, cameraPos);
+			float f = clamp(1.0 - (dist - minDist) / (maxDist - minDist), 0.01, 1.0) * tess;
+			return f;
+		}
+
+		float4 CalcTriEdgeTessFactors (float3 triVertexFactors)
+		{
+			float4 tess;
+			tess.x = 0.5 * (triVertexFactors.y + triVertexFactors.z);
+			tess.y = 0.5 * (triVertexFactors.x + triVertexFactors.z);
+			tess.z = 0.5 * (triVertexFactors.x + triVertexFactors.y);
+			tess.w = (triVertexFactors.x + triVertexFactors.y + triVertexFactors.z) / 3.0f;
+			return tess;
+		}
+
+		float CalcEdgeTessFactor (float3 wpos0, float3 wpos1, float edgeLen, float3 cameraPos, float4 scParams )
+		{
+			float dist = distance (0.5 * (wpos0+wpos1), cameraPos);
+			float len = distance(wpos0, wpos1);
+			float f = max(len * scParams.y / (edgeLen * dist), 1.0);
+			return f;
+		}
+
+		float DistanceFromPlane (float3 pos, float4 plane)
+		{
+			float d = dot (float4(pos,1.0f), plane);
+			return d;
+		}
+
+		bool WorldViewFrustumCull (float3 wpos0, float3 wpos1, float3 wpos2, float cullEps, float4 planes[6] )
+		{
+			float4 planeTest;
+			planeTest.x = (( DistanceFromPlane(wpos0, planes[0]) > -cullEps) ? 1.0f : 0.0f ) +
+							(( DistanceFromPlane(wpos1, planes[0]) > -cullEps) ? 1.0f : 0.0f ) +
+							(( DistanceFromPlane(wpos2, planes[0]) > -cullEps) ? 1.0f : 0.0f );
+			planeTest.y = (( DistanceFromPlane(wpos0, planes[1]) > -cullEps) ? 1.0f : 0.0f ) +
+							(( DistanceFromPlane(wpos1, planes[1]) > -cullEps) ? 1.0f : 0.0f ) +
+							(( DistanceFromPlane(wpos2, planes[1]) > -cullEps) ? 1.0f : 0.0f );
+			planeTest.z = (( DistanceFromPlane(wpos0, planes[2]) > -cullEps) ? 1.0f : 0.0f ) +
+							(( DistanceFromPlane(wpos1, planes[2]) > -cullEps) ? 1.0f : 0.0f ) +
+							(( DistanceFromPlane(wpos2, planes[2]) > -cullEps) ? 1.0f : 0.0f );
+			planeTest.w = (( DistanceFromPlane(wpos0, planes[3]) > -cullEps) ? 1.0f : 0.0f ) +
+							(( DistanceFromPlane(wpos1, planes[3]) > -cullEps) ? 1.0f : 0.0f ) +
+							(( DistanceFromPlane(wpos2, planes[3]) > -cullEps) ? 1.0f : 0.0f );
+			return !all (planeTest);
+		}
+
+		float4 DistanceBasedTess( float4 v0, float4 v1, float4 v2, float tess, float minDist, float maxDist, float4x4 o2w, float3 cameraPos )
+		{
+			float3 f;
+			f.x = CalcDistanceTessFactor (v0,minDist,maxDist,tess,o2w,cameraPos);
+			f.y = CalcDistanceTessFactor (v1,minDist,maxDist,tess,o2w,cameraPos);
+			f.z = CalcDistanceTessFactor (v2,minDist,maxDist,tess,o2w,cameraPos);
+
+			return CalcTriEdgeTessFactors (f);
+		}
+
+		float4 EdgeLengthBasedTess( float4 v0, float4 v1, float4 v2, float edgeLength, float4x4 o2w, float3 cameraPos, float4 scParams )
+		{
+			float3 pos0 = mul(o2w,v0).xyz;
+			float3 pos1 = mul(o2w,v1).xyz;
+			float3 pos2 = mul(o2w,v2).xyz;
+			float4 tess;
+			tess.x = CalcEdgeTessFactor (pos1, pos2, edgeLength, cameraPos, scParams);
+			tess.y = CalcEdgeTessFactor (pos2, pos0, edgeLength, cameraPos, scParams);
+			tess.z = CalcEdgeTessFactor (pos0, pos1, edgeLength, cameraPos, scParams);
+			tess.w = (tess.x + tess.y + tess.z) / 3.0f;
+			return tess;
+		}
+
+		float4 EdgeLengthBasedTessCull( float4 v0, float4 v1, float4 v2, float edgeLength, float maxDisplacement, float4x4 o2w, float3 cameraPos, float4 scParams, float4 planes[6] )
+		{
+			float3 pos0 = mul(o2w,v0).xyz;
+			float3 pos1 = mul(o2w,v1).xyz;
+			float3 pos2 = mul(o2w,v2).xyz;
+			float4 tess;
+
+			if (WorldViewFrustumCull(pos0, pos1, pos2, maxDisplacement, planes))
+			{
+				tess = 0.0f;
+			}
+			else
+			{
+				tess.x = CalcEdgeTessFactor (pos1, pos2, edgeLength, cameraPos, scParams);
+				tess.y = CalcEdgeTessFactor (pos2, pos0, edgeLength, cameraPos, scParams);
+				tess.z = CalcEdgeTessFactor (pos0, pos1, edgeLength, cameraPos, scParams);
+				tess.w = (tess.x + tess.y + tess.z) / 3.0f;
+			}
+			return tess;
+		}
+		#endif //ASE_TESS_FUNCS
+		ENDHLSL
+
+		/*ase_pass*/
+		Pass
+		{
+			/*ase_main_pass*/
+			Name "Forward"
+			Tags
+			{
+				"LightMode" = "UniversalForward"
+		    }
+
+			Blend One Zero
+			ZWrite On
+			ZTest LEqual
+			Offset 0,0
+			ColorMask RGBA
+
+			/*ase_stencil*/
+
+			HLSLPROGRAM
+
+			#pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+			#pragma multi_compile _ _ADDITIONAL_LIGHTS_VERTEX _ADDITIONAL_LIGHTS
+            #pragma multi_compile _ EVALUATE_SH_MIXED EVALUATE_SH_VERTEX
+			#pragma multi_compile_fragment _ _ADDITIONAL_LIGHT_SHADOWS
+			#pragma multi_compile_fragment _ _REFLECTION_PROBE_BLENDING
+			#pragma multi_compile_fragment _ _REFLECTION_PROBE_BOX_PROJECTION
+			#pragma multi_compile_fragment _ _REFLECTION_PROBE_ATLAS
+			#pragma multi_compile_fragment _ _SHADOWS_SOFT _SHADOWS_SOFT_LOW _SHADOWS_SOFT_MEDIUM _SHADOWS_SOFT_HIGH
+			#pragma multi_compile_fragment _ _SCREEN_SPACE_IRRADIANCE
+			#pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+			#pragma multi_compile _ _LIGHT_LAYERS
+			// #pragma multi_compile_fragment _ _LIGHT_COOKIES
+			#pragma multi_compile _ _CLUSTER_LIGHT_LOOP
+
+			// @IllusionRP Start
+			#pragma multi_compile_fragment _ _PRT_GLOBAL_ILLUMINATION
+			#pragma multi_compile_fragment _ _SCREEN_SPACE_REFLECTION
+			#pragma multi_compile_fragment _ _SCREEN_SPACE_GLOBAL_ILLUMINATION
+			#pragma multi_compile_fragment _ _SHADOW_BIAS_FRAGMENT
+			#pragma shader_feature_local_fragment _ _WATER_REFLECTION_LEGACY
+			// @IllusionRP End
+
+			#pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+			#pragma multi_compile _ SHADOWS_SHADOWMASK
+			#pragma multi_compile _ DIRLIGHTMAP_COMBINED
+			#pragma multi_compile _ LIGHTMAP_ON
+			#pragma multi_compile_fragment _ LIGHTMAP_BICUBIC_SAMPLING
+			#pragma multi_compile_fragment _ REFLECTION_PROBE_ROTATION
+			#pragma multi_compile _ DYNAMICLIGHTMAP_ON
+			#pragma multi_compile _ USE_LEGACY_LIGHTMAPS
+
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#if defined( _SPECULAR_SETUP ) && defined( ASE_LIGHTING_SIMPLE )
+				#if defined( _SPECULARHIGHLIGHTS_OFF )
+					#undef _SPECULAR_COLOR
+				#else
+					#define _SPECULAR_COLOR
+				#endif
+			#endif
+
+			#define SHADERPASS SHADERPASS_FORWARD
+
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Fog.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Texture.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Lit/Lighting.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/TextureStack.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DBuffer.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
+
+			#if defined(LOD_FADE_CROSSFADE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+            #endif
+
+			#if defined( UNITY_INSTANCING_ENABLED ) && defined( ASE_INSTANCED_TERRAIN ) && ( defined(_TERRAIN_INSTANCED_PERPIXEL_NORMAL) || defined(_INSTANCEDTERRAINNORMALS_PIXEL) )
+				#define ENABLE_TERRAIN_PERPIXEL_NORMAL
+			#endif
+
+			/*ase_pragma*/
+
+			#if defined(ASE_EARLY_Z_DEPTH_OPTIMIZE) && (SHADER_TARGET >= 45)
+				#define ASE_SV_DEPTH SV_DepthLessEqual
+				#define ASE_SV_POSITION_QUALIFIERS linear noperspective centroid
+			#else
+				#define ASE_SV_DEPTH SV_Depth
+				#define ASE_SV_POSITION_QUALIFIERS
+			#endif
+
+			struct Attributes
+			{
+				float4 positionOS : POSITION;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				float4 texcoord : TEXCOORD0;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					float4 texcoord1 : TEXCOORD1;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					float4 texcoord2 : TEXCOORD2;
+				#endif
+				/*ase_vdata:p=p;n=n;t=t;uv0=tc0;uv1=tc1;uv2=tc2*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct PackedVaryings
+			{
+				ASE_SV_POSITION_QUALIFIERS float4 positionCS : SV_POSITION;
+				float3 positionWS : TEXCOORD0;
+				half3 normalWS : TEXCOORD1;
+				float4 tangentWS : TEXCOORD2; // holds terrainUV ifdef ENABLE_TERRAIN_PERPIXEL_NORMAL
+				float4 lightmapUVOrVertexSH : TEXCOORD3;
+				#if defined(ASE_FOG) || defined(_ADDITIONAL_LIGHTS_VERTEX)
+					half4 fogFactorAndVertexLight : TEXCOORD4;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON)
+					float2 dynamicLightmapUV : TEXCOORD5;
+				#endif
+				#if defined(USE_APV_PROBE_OCCLUSION)
+					float4 probeOcclusion : TEXCOORD6;
+				#endif
+				/*ase_interp(7,):sp=sp;wp=tc0.xyz;wn.xyz=tc1.xyz;wt=tc2*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+			#ifdef ASE_TRANSMISSION
+				float _TransmissionShadow;
+			#endif
+			#ifdef ASE_TRANSLUCENCY
+				float _TransStrength;
+				float _TransNormal;
+				float _TransScattering;
+				float _TransDirect;
+				float _TransAmbient;
+				float _TransShadow;
+			#endif
+			#ifdef ASE_TESSELLATION
+				float _TessPhongStrength;
+				float _TessValue;
+				float _TessMin;
+				float _TessMax;
+				float _TessEdgeLength;
+				float _TessMaxDisp;
+			#endif
+			CBUFFER_END
+
+			#ifdef SCENEPICKINGPASS
+				float4 _SelectionID;
+			#endif
+
+			#ifdef SCENESELECTIONPASS
+				int _ObjectId;
+				int _PassValue;
+			#endif
+
+			/*ase_globals*/
+
+			/*ase_funcs*/
+
+			PackedVaryings VertexFunction( Attributes input /*ase_vert_input*/ )
+			{
+				PackedVaryings output = (PackedVaryings)0;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+				/*ase_vert_code:input=Attributes;output=PackedVaryings*/
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					float3 defaultVertexValue = input.positionOS.xyz;
+				#else
+					float3 defaultVertexValue = float3(0, 0, 0);
+				#endif
+
+				float3 vertexValue = /*ase_vert_out:Vertex Offset;Float3;8;-1;_Vertex*/defaultVertexValue/*end*/;
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					input.positionOS.xyz = vertexValue;
+				#else
+					input.positionOS.xyz += vertexValue;
+				#endif
+				input.normalOS = /*ase_vert_out:Vertex Normal;Float3;10;-1;_Normal*/input.normalOS/*end*/;
+				input.tangentOS = /*ase_vert_out:Vertex Tangent;Float4;30;-1;_Tangent*/input.tangentOS/*end*/;
+
+				VertexPositionInputs vertexInput = GetVertexPositionInputs( input.positionOS.xyz );
+				VertexNormalInputs normalInput = GetVertexNormalInputs( input.normalOS, input.tangentOS );
+
+				OUTPUT_LIGHTMAP_UV(input.texcoord1, unity_LightmapST, output.lightmapUVOrVertexSH.xy);
+				#if defined(DYNAMICLIGHTMAP_ON)
+					output.dynamicLightmapUV.xy = input.texcoord2.xy * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
+				#endif
+				OUTPUT_SH4(vertexInput.positionWS, normalInput.normalWS.xyz, GetWorldSpaceNormalizeViewDir(vertexInput.positionWS), output.lightmapUVOrVertexSH.xyz, output.probeOcclusion);
+
+				#if defined(ASE_FOG) || defined(_ADDITIONAL_LIGHTS_VERTEX)
+					output.fogFactorAndVertexLight = 0;
+					#if defined(ASE_FOG) && !defined(_FOG_FRAGMENT)
+						output.fogFactorAndVertexLight.x = ComputeFogFactor(vertexInput.positionCS.z);
+					#endif
+					#ifdef _ADDITIONAL_LIGHTS_VERTEX
+						half3 vertexLight = VertexLighting( vertexInput.positionWS, normalInput.normalWS );
+						output.fogFactorAndVertexLight.yzw = vertexLight;
+					#endif
+				#endif
+
+				output.positionCS = vertexInput.positionCS;
+				output.positionWS = vertexInput.positionWS;
+				output.normalWS = normalInput.normalWS;
+				output.tangentWS = float4( normalInput.tangentWS, ( input.tangentOS.w > 0.0 ? 1.0 : -1.0 ) * GetOddNegativeScale() );
+
+				#if defined( ENABLE_TERRAIN_PERPIXEL_NORMAL )
+					output.tangentWS.zw = input.texcoord.xy;
+					output.tangentWS.xy = input.texcoord.xy * unity_LightmapST.xy + unity_LightmapST.zw;
+				#endif
+				return output;
+			}
+
+			#if defined(ASE_TESSELLATION)
+			struct VertexControl
+			{
+				float4 positionOS : INTERNALTESSPOS;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				float4 texcoord : TEXCOORD0;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					float4 texcoord1 : TEXCOORD1;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					float4 texcoord2 : TEXCOORD2;
+				#endif
+				/*ase_vcontrol*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct TessellationFactors
+			{
+				float edge[3] : SV_TessFactor;
+				float inside : SV_InsideTessFactor;
+			};
+
+			VertexControl vert ( Attributes input )
+			{
+				VertexControl output;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				output.positionOS = input.positionOS;
+				output.normalOS = input.normalOS;
+				output.tangentOS = input.tangentOS;
+				output.texcoord = input.texcoord;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					output.texcoord1 = input.texcoord1;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					output.texcoord2 = input.texcoord2;
+				#endif
+				/*ase_control_code:input=Attributes;output=VertexControl*/
+				return output;
+			}
+
+			TessellationFactors TessellationFunction (InputPatch<VertexControl,3> input)
+			{
+				TessellationFactors output;
+				float4 tf = 1;
+				float tessValue = /*ase_inline_begin*/_TessValue/*ase_inline_end*/; float tessMin = /*ase_inline_begin*/_TessMin/*ase_inline_end*/; float tessMax = /*ase_inline_begin*/_TessMax/*ase_inline_end*/;
+				float edgeLength = /*ase_inline_begin*/_TessEdgeLength/*ase_inline_end*/; float tessMaxDisp = /*ase_inline_begin*/_TessMaxDisp/*ase_inline_end*/;
+				#if defined(ASE_FIXED_TESSELLATION)
+				tf = FixedTess( tessValue );
+				#elif defined(ASE_DISTANCE_TESSELLATION)
+				tf = DistanceBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, tessValue, tessMin, tessMax, GetObjectToWorldMatrix(), _WorldSpaceCameraPos );
+				#elif defined(ASE_LENGTH_TESSELLATION)
+				tf = EdgeLengthBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams );
+				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+				tf = EdgeLengthBasedTessCull(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, tessMaxDisp, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
+				#endif
+				output.edge[0] = tf.x; output.edge[1] = tf.y; output.edge[2] = tf.z; output.inside = tf.w;
+				return output;
+			}
+
+			[domain("tri")]
+			[partitioning("fractional_odd")]
+			[outputtopology("triangle_cw")]
+			[patchconstantfunc("TessellationFunction")]
+			[outputcontrolpoints(3)]
+			VertexControl HullFunction(InputPatch<VertexControl, 3> patch, uint id : SV_OutputControlPointID)
+			{
+				return patch[id];
+			}
+
+			[domain("tri")]
+			PackedVaryings DomainFunction(TessellationFactors factors, OutputPatch<VertexControl, 3> patch, float3 bary : SV_DomainLocation)
+			{
+				Attributes output = (Attributes) 0;
+				output.positionOS = patch[0].positionOS * bary.x + patch[1].positionOS * bary.y + patch[2].positionOS * bary.z;
+				output.normalOS = patch[0].normalOS * bary.x + patch[1].normalOS * bary.y + patch[2].normalOS * bary.z;
+				output.tangentOS = patch[0].tangentOS * bary.x + patch[1].tangentOS * bary.y + patch[2].tangentOS * bary.z;
+				output.texcoord = patch[0].texcoord * bary.x + patch[1].texcoord * bary.y + patch[2].texcoord * bary.z;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					output.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					output.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
+				#endif
+				/*ase_domain_code:patch=VertexControl;output=Attributes;bary=SV_DomainLocation*/
+				#if defined(ASE_PHONG_TESSELLATION)
+				float3 pp[3];
+				for (int i = 0; i < 3; ++i)
+					pp[i] = output.positionOS.xyz - patch[i].normalOS * (dot(output.positionOS.xyz, patch[i].normalOS) - dot(patch[i].positionOS.xyz, patch[i].normalOS));
+				float phongStrength = /*ase_inline_begin*/_TessPhongStrength/*ase_inline_end*/;
+				output.positionOS.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * output.positionOS.xyz;
+				#endif
+				UNITY_TRANSFER_INSTANCE_ID(patch[0], output);
+				return VertexFunction(output);
+			}
+			#else
+			PackedVaryings vert ( Attributes input )
+			{
+				return VertexFunction( input );
+			}
+			#endif
+
+			half4 frag ( PackedVaryings input
+						#if defined( ASE_DEPTH_WRITE_ON )
+						,out float outputDepth : ASE_SV_DEPTH
+						#endif
+						#ifdef _WRITE_RENDERING_LAYERS
+						, out uint outRenderingLayers : SV_Target1
+						#endif
+						/*ase_frag_input*/ ) : SV_Target
+			{
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+				#if defined( _SURFACE_TYPE_TRANSPARENT )
+					const bool isTransparent = true;
+				#else
+					const bool isTransparent = false;
+				#endif
+
+				#if defined(LOD_FADE_CROSSFADE)
+					LODFadeCrossFade( input.positionCS );
+				#endif
+
+				#if defined(MAIN_LIGHT_CALCULATE_SHADOWS)
+					float4 shadowCoord = TransformWorldToShadowCoord( input.positionWS );
+				#else
+					float4 shadowCoord = float4(0, 0, 0, 0);
+				#endif
+
+				// @diogo: mikktspace compliant
+				float renormFactor = 1.0 / max( FLT_MIN, length( input.normalWS ) );
+
+				/*ase_local_var:wp*/float3 PositionWS = input.positionWS;
+				/*ase_local_var:rwp*/float3 PositionRWS = GetCameraRelativePositionWS( PositionWS );
+				/*ase_local_var:wvd*/float3 ViewDirWS = GetWorldSpaceNormalizeViewDir( PositionWS );
+				/*ase_local_var:sc*/float4 ShadowCoord = shadowCoord;
+				/*ase_local_var:spn*/float4 ScreenPosNorm = float4( GetNormalizedScreenSpaceUV( input.positionCS ), input.positionCS.zw );
+				/*ase_local_var:sp*/float4 ClipPos = ComputeClipSpacePosition( ScreenPosNorm.xy, input.positionCS.z ) * input.positionCS.w;
+				/*ase_local_var:spu*/float4 ScreenPos = ComputeScreenPos( ClipPos );
+				/*ase_local_var:wt*/float3 TangentWS = input.tangentWS.xyz * renormFactor;
+				/*ase_local_var:wbt*/float3 BitangentWS = cross( input.normalWS, input.tangentWS.xyz ) * input.tangentWS.w * renormFactor;
+				/*ase_local_var:wn*/float3 NormalWS = input.normalWS * renormFactor;
+
+				#if defined( ENABLE_TERRAIN_PERPIXEL_NORMAL )
+					float2 sampleCoords = (input.tangentWS.zw / _TerrainHeightmapRecipSize.zw + 0.5f) * _TerrainHeightmapRecipSize.xy;
+					NormalWS = TransformObjectToWorldNormal(normalize(SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_TerrainNormalmapTexture, sampleCoords).rgb * 2 - 1));
+					TangentWS = -cross(GetObjectToWorldMatrix()._13_23_33, NormalWS);
+					BitangentWS = cross(NormalWS, -TangentWS);
+				#endif
+
+				/*ase_frag_code:input=PackedVaryings*/
+
+				float3 BaseColor = /*ase_frag_out:Base Color;Float3;0;-1;_BaseColor*/float3(0.5, 0.5, 0.5)/*end*/;
+				float3 Normal = /*ase_frag_out:Normal;Float3;1;-1;_FragNormal*/float3(0, 0, 1)/*end*/;
+				float3 Specular = /*ase_frag_out:Specular;Float3;9;-1;_Specular*/0.5/*end*/;
+				float Metallic = /*ase_frag_out:Metallic;Float;3;-1;_Metallic*/0/*end*/;
+				float Smoothness = /*ase_frag_out:Smoothness;Float;4;-1;_Smoothness*/0.5/*end*/;
+				float Occlusion = /*ase_frag_out:Occlusion;Float;5;-1;_Occlusion*/1/*end*/;
+				float3 Emission = /*ase_frag_out:Emission;Float3;2;-1;_Emission*/0/*end*/;
+				float Alpha = /*ase_frag_out:Alpha;Float;6;-1;_Alpha*/1/*end*/;
+				float AlphaClipThreshold = /*ase_frag_out:Alpha Clip Threshold;Float;7;-1;_AlphaClip*/0.5/*end*/;
+				float AlphaClipThresholdShadow = /*ase_frag_out:Alpha Clip Threshold Shadow;Float;16;-1;_AlphaClipShadow*/0.5/*end*/;
+				float3 BakedGI = /*ase_frag_out:Baked GI;Float3;11;-1;_BakedGI*/0/*end*/;
+				float3 RefractionColor = /*ase_frag_out:Refraction Color;Float3;12;-1;_RefractionColor*/1/*end*/;
+				float RefractionIndex = /*ase_frag_out:Refraction Index;Float;13;-1;_RefractionIndex*/1/*end*/;
+				float3 Transmission = /*ase_frag_out:Transmission;Float3;14;-1;_Transmission*/1/*end*/;
+				float3 Translucency = /*ase_frag_out:Translucency;Float3;15;-1;_Translucency*/1/*end*/;
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					float DeviceDepth = /*ase_frag_out:Depth;Float;17;-1;_DepthValue*/ClipPos.z/*end*/;
+				#endif
+
+				#ifdef _CLEARCOAT
+					float CoatMask = /*ase_frag_out:Coat Mask;Float;18;-1;_CoatMask*/0/*end*/;
+					float CoatSmoothness = /*ase_frag_out:Coat Smoothness;Float;20;-1;_clearCoatSmoothness*/0/*end*/;
+				#endif
+
+				#if defined( _ALPHATEST_ON )
+					AlphaDiscard( Alpha, AlphaClipThreshold );
+				#endif
+
+				#if defined(MAIN_LIGHT_CALCULATE_SHADOWS) && defined(ASE_CHANGES_WORLD_POS)
+					ShadowCoord = TransformWorldToShadowCoord( PositionWS );
+				#endif
+
+				InputData inputData = (InputData)0;
+				inputData.positionWS = PositionWS;
+				inputData.positionCS = float4( input.positionCS.xy, ClipPos.zw / ClipPos.w );
+				inputData.normalizedScreenSpaceUV = ScreenPosNorm.xy;
+				inputData.viewDirectionWS = ViewDirWS;
+				inputData.shadowCoord = ShadowCoord;
+
+				#ifdef _NORMALMAP
+						#if _NORMAL_DROPOFF_TS
+							inputData.normalWS = TransformTangentToWorld(Normal, half3x3(TangentWS, BitangentWS, NormalWS));
+						#elif _NORMAL_DROPOFF_OS
+							inputData.normalWS = TransformObjectToWorldNormal(Normal);
+						#elif _NORMAL_DROPOFF_WS
+							inputData.normalWS = Normal;
+						#endif
+					inputData.normalWS = NormalizeNormalPerPixel(inputData.normalWS);
+				#else
+					inputData.normalWS = NormalWS;
+				#endif
+
+				#ifdef ASE_FOG
+					inputData.fogCoord = InitializeInputDataFog(float4(inputData.positionWS, 1.0), input.fogFactorAndVertexLight.x);
+				#endif
+				#ifdef _ADDITIONAL_LIGHTS_VERTEX
+					inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
+				#endif
+
+				#if defined( ENABLE_TERRAIN_PERPIXEL_NORMAL )
+					float3 SH = SampleSH(inputData.normalWS.xyz);
+				#else
+					float3 SH = input.lightmapUVOrVertexSH.xyz;
+				#endif
+
+				#if defined(_SCREEN_SPACE_IRRADIANCE)
+					inputData.bakedGI = SAMPLE_GI(_ScreenSpaceIrradiance, input.positionCS.xy);
+				#elif defined(DYNAMICLIGHTMAP_ON)
+					inputData.bakedGI = SAMPLE_GI(input.lightmapUVOrVertexSH.xy, input.dynamicLightmapUV.xy, SH, inputData.normalWS);
+					inputData.shadowMask = SAMPLE_SHADOWMASK(input.lightmapUVOrVertexSH.xy);
+				#elif !defined(LIGHTMAP_ON) && (defined(PROBE_VOLUMES_L1) || defined(PROBE_VOLUMES_L2))
+					inputData.bakedGI = SAMPLE_GI( SH, GetAbsolutePositionWS(inputData.positionWS),
+						inputData.normalWS,
+						inputData.viewDirectionWS,
+						input.positionCS.xy,
+						input.probeOcclusion,
+						inputData.shadowMask );
+				#else
+					inputData.bakedGI = SAMPLE_GI(input.lightmapUVOrVertexSH.xy, SH, inputData.normalWS);
+					inputData.shadowMask = SAMPLE_SHADOWMASK(input.lightmapUVOrVertexSH.xy);
+				#endif
+
+				#ifdef ASE_BAKEDGI
+					inputData.bakedGI = BakedGI;
+				#endif
+
+				#if defined(DEBUG_DISPLAY)
+					#if defined(DYNAMICLIGHTMAP_ON)
+						inputData.dynamicLightmapUV = input.dynamicLightmapUV.xy;
+					#endif
+					#if defined(LIGHTMAP_ON)
+						inputData.staticLightmapUV = input.lightmapUVOrVertexSH.xy;
+					#else
+						inputData.vertexSH = SH;
+					#endif
+					#if defined(USE_APV_PROBE_OCCLUSION)
+						inputData.probeOcclusion = input.probeOcclusion;
+					#endif
+				#endif
+
+				SurfaceData surfaceData;
+				surfaceData.albedo              = BaseColor;
+				surfaceData.metallic            = saturate(Metallic);
+				surfaceData.specular            = Specular;
+				surfaceData.smoothness          = saturate(Smoothness),
+				surfaceData.occlusion           = Occlusion,
+				surfaceData.emission            = Emission,
+				surfaceData.alpha               = saturate(Alpha);
+				surfaceData.normalTS            = Normal;
+				surfaceData.clearCoatMask       = 0;
+				surfaceData.clearCoatSmoothness = 1;
+
+				#ifdef _CLEARCOAT
+					surfaceData.clearCoatMask       = saturate(CoatMask);
+					surfaceData.clearCoatSmoothness = saturate(CoatSmoothness);
+				#endif
+
+				#if defined(_DBUFFER)
+					ApplyDecalToSurfaceData(input.positionCS, surfaceData, inputData);
+				#endif
+
+				#ifdef ASE_LIGHTING_SIMPLE
+					half4 color = UniversalFragmentBlinnPhong( inputData, surfaceData);
+				#else
+					half4 color = UniversalFragmentPBR( inputData, surfaceData);
+				#endif
+
+				#ifdef ASE_TRANSMISSION
+				{
+					float shadow = /*ase_inline_begin*/_TransmissionShadow/*ase_inline_end*/;
+
+					#define SUM_LIGHT_TRANSMISSION(Light)\
+						float3 atten = Light.color * Light.distanceAttenuation;\
+						atten = lerp( atten, atten * Light.shadowAttenuation, shadow );\
+						half3 transmission = max( 0, -dot( inputData.normalWS, Light.direction ) ) * atten * Transmission;\
+						color.rgb += BaseColor * transmission;
+
+					SUM_LIGHT_TRANSMISSION( IllusionGetMainLight( MAIN_LIGHT_SHADOW_COORD(inputData.shadowCoord) ) );
+
+					#if defined(_ADDITIONAL_LIGHTS)
+						uint meshRenderingLayers = GetMeshRenderingLayer();
+						uint pixelLightCount = GetAdditionalLightsCount();
+						#if USE_CLUSTER_LIGHT_LOOP
+							[loop] for (uint lightIndex = 0; lightIndex < min(URP_FP_DIRECTIONAL_LIGHTS_COUNT, MAX_VISIBLE_LIGHTS); lightIndex++)
+							{
+								CLUSTER_LIGHT_LOOP_SUBTRACTIVE_LIGHT_CHECK
+
+								Light light = GetAdditionalLight(lightIndex, inputData.positionWS, inputData.shadowMask);
+								#ifdef _LIGHT_LAYERS
+								if (IsMatchingLightLayer(light.layerMask, meshRenderingLayers))
+								#endif
+								{
+									SUM_LIGHT_TRANSMISSION( light );
+								}
+							}
+						#endif
+						LIGHT_LOOP_BEGIN( pixelLightCount )
+							Light light = GetAdditionalLight(lightIndex, inputData.positionWS, inputData.shadowMask);
+							#ifdef _LIGHT_LAYERS
+							if (IsMatchingLightLayer(light.layerMask, meshRenderingLayers))
+							#endif
+							{
+								SUM_LIGHT_TRANSMISSION( light );
+							}
+						LIGHT_LOOP_END
+					#endif
+				}
+				#endif
+
+				#ifdef ASE_TRANSLUCENCY
+				{
+					float shadow = /*ase_inline_begin*/_TransShadow/*ase_inline_end*/;
+					float normal = /*ase_inline_begin*/_TransNormal/*ase_inline_end*/;
+					float scattering = /*ase_inline_begin*/_TransScattering/*ase_inline_end*/;
+					float direct = /*ase_inline_begin*/_TransDirect/*ase_inline_end*/;
+					float ambient = /*ase_inline_begin*/_TransAmbient/*ase_inline_end*/;
+					float strength = /*ase_inline_begin*/_TransStrength/*ase_inline_end*/;
+
+					#define SUM_LIGHT_TRANSLUCENCY(Light)\
+						float3 atten = Light.color * Light.distanceAttenuation;\
+						atten = lerp( atten, atten * Light.shadowAttenuation, shadow );\
+						half3 lightDir = Light.direction + inputData.normalWS * normal;\
+						half VdotL = pow( saturate( dot( inputData.viewDirectionWS, -lightDir ) ), scattering );\
+						half3 translucency = atten * ( VdotL * direct + inputData.bakedGI * ambient ) * Translucency;\
+						color.rgb += BaseColor * translucency * strength;
+
+					SUM_LIGHT_TRANSLUCENCY( IllusionGetMainLight( MAIN_LIGHT_SHADOW_COORD(inputData.shadowCoord) ) );
+
+					#if defined(_ADDITIONAL_LIGHTS)
+						uint meshRenderingLayers = GetMeshRenderingLayer();
+						uint pixelLightCount = GetAdditionalLightsCount();
+						#if USE_CLUSTER_LIGHT_LOOP
+							[loop] for (uint lightIndex = 0; lightIndex < min(URP_FP_DIRECTIONAL_LIGHTS_COUNT, MAX_VISIBLE_LIGHTS); lightIndex++)
+							{
+								CLUSTER_LIGHT_LOOP_SUBTRACTIVE_LIGHT_CHECK
+
+								Light light = GetAdditionalLight(lightIndex, inputData.positionWS, inputData.shadowMask);
+								#ifdef _LIGHT_LAYERS
+								if (IsMatchingLightLayer(light.layerMask, meshRenderingLayers))
+								#endif
+								{
+									SUM_LIGHT_TRANSLUCENCY( light );
+								}
+							}
+						#endif
+						LIGHT_LOOP_BEGIN( pixelLightCount )
+							Light light = GetAdditionalLight(lightIndex, inputData.positionWS, inputData.shadowMask);
+							#ifdef _LIGHT_LAYERS
+							if (IsMatchingLightLayer(light.layerMask, meshRenderingLayers))
+							#endif
+							{
+								SUM_LIGHT_TRANSLUCENCY( light );
+							}
+						LIGHT_LOOP_END
+					#endif
+				}
+				#endif
+
+				#ifdef ASE_REFRACTION
+					float4 projScreenPos = ScreenPos / ScreenPos.w;
+					float3 refractionOffset = ( RefractionIndex - 1.0 ) * mul( UNITY_MATRIX_V, float4( NormalWS,0 ) ).xyz * ( 1.0 - dot( NormalWS, ViewDirWS ) );
+					projScreenPos.xy += refractionOffset.xy;
+					float3 refraction = SHADERGRAPH_SAMPLE_SCENE_COLOR( projScreenPos.xy ) * RefractionColor;
+					color.rgb = lerp( refraction, color.rgb, color.a );
+					color.a = 1;
+				#endif
+
+				#ifdef ASE_FINAL_COLOR_ALPHA_MULTIPLY
+					color.rgb *= color.a;
+				#endif
+
+				#ifdef ASE_FOG
+					#ifdef TERRAIN_SPLAT_ADDPASS
+						color.rgb = MixFogColor(color.rgb, half3(0,0,0), inputData.fogCoord);
+					#else
+						color.rgb = MixFog(color.rgb, inputData.fogCoord);
+					#endif
+				#endif
+
+				#ifdef _SURFACE_TYPE_TRANSPARENT
+					color.rgb = lerp(SamplePreRefractionColor(ScreenPosNorm.xy), color.rgb, saturate(color.a));
+					color.a = 1.0;
+				#endif
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					outputDepth = DeviceDepth;
+				#endif
+
+				#ifdef _WRITE_RENDERING_LAYERS
+					outRenderingLayers = EncodeMeshRenderingLayer();
+				#endif
+
+				#if defined( ASE_OPAQUE_KEEP_ALPHA )
+					return half4( color.rgb, color.a );
+				#else
+					return half4( color.rgb, OutputAlpha( color.a, isTransparent ) );
+				#endif
+			}
+			ENDHLSL
+		}
+
+		/*ase_pass*/
+		Pass
+		{
+			/*ase_hide_pass*/
+			Name "ShadowCaster"
+			Tags
+			{
+				"LightMode" = "ShadowCaster"
+		    }
+
+			ZWrite On
+			ZTest LEqual
+			AlphaToMask Off
+			ColorMask 0
+
+			HLSLPROGRAM
+
+			#pragma multi_compile_vertex _ _CASTING_PUNCTUAL_LIGHT_SHADOW
+			#pragma multi_compile_vertex _ _SHADOW_BIAS_FRAGMENT
+
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#if defined( _SPECULAR_SETUP ) && defined( ASE_LIGHTING_SIMPLE )
+				#if defined( _SPECULARHIGHLIGHTS_OFF )
+					#undef _SPECULAR_COLOR
+				#else
+					#define _SPECULAR_COLOR
+				#endif
+			#endif
+
+			#define SHADERPASS SHADERPASS_SHADOWCASTER
+
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Texture.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Lit/Lighting.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/TextureStack.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
+
+			#if defined(LOD_FADE_CROSSFADE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+            #endif
+
+			/*ase_pragma*/
+
+			#if defined(ASE_EARLY_Z_DEPTH_OPTIMIZE) && (SHADER_TARGET >= 45)
+				#define ASE_SV_DEPTH SV_DepthLessEqual
+				#define ASE_SV_POSITION_QUALIFIERS linear noperspective centroid
+			#else
+				#define ASE_SV_DEPTH SV_Depth
+				#define ASE_SV_POSITION_QUALIFIERS
+			#endif
+
+			struct Attributes
+			{
+				float4 positionOS : POSITION;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				/*ase_vdata:p=p;n=n;t=t*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct PackedVaryings
+			{
+				ASE_SV_POSITION_QUALIFIERS float4 positionCS : SV_POSITION;
+				float3 positionWS : TEXCOORD0;
+				/*ase_interp(1,):sp=sp;wp=tc0.xyz*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+			#ifdef ASE_TRANSMISSION
+				float _TransmissionShadow;
+			#endif
+			#ifdef ASE_TRANSLUCENCY
+				float _TransStrength;
+				float _TransNormal;
+				float _TransScattering;
+				float _TransDirect;
+				float _TransAmbient;
+				float _TransShadow;
+			#endif
+			#ifdef ASE_TESSELLATION
+				float _TessPhongStrength;
+				float _TessValue;
+				float _TessMin;
+				float _TessMax;
+				float _TessEdgeLength;
+				float _TessMaxDisp;
+			#endif
+			CBUFFER_END
+
+			#ifdef SCENEPICKINGPASS
+				float4 _SelectionID;
+			#endif
+
+			#ifdef SCENESELECTIONPASS
+				int _ObjectId;
+				int _PassValue;
+			#endif
+
+			/*ase_globals*/
+
+			float3 _LightDirection;
+			float3 _LightPosition;
+
+			/*ase_funcs*/
+
+			PackedVaryings VertexFunction( Attributes input/*ase_vert_input*/ )
+			{
+				PackedVaryings output;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO( output );
+
+				/*ase_vert_code:input=Attributes;output=PackedVaryings*/
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					float3 defaultVertexValue = input.positionOS.xyz;
+				#else
+					float3 defaultVertexValue = float3(0, 0, 0);
+				#endif
+
+				float3 vertexValue = /*ase_vert_out:Vertex Offset;Float3;8;-1;_Vertex*/defaultVertexValue/*end*/;
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					input.positionOS.xyz = vertexValue;
+				#else
+					input.positionOS.xyz += vertexValue;
+				#endif
+
+				input.normalOS = /*ase_vert_out:Vertex Normal;Float3;10;-1;_Normal*/input.normalOS/*end*/;
+				input.tangentOS = /*ase_vert_out:Vertex Tangent;Float4;30;-1;_Tangent*/input.tangentOS/*end*/;
+
+				float3 positionWS = TransformObjectToWorld( input.positionOS.xyz );
+				float3 normalWS = TransformObjectToWorldDir(input.normalOS);
+
+				#if _CASTING_PUNCTUAL_LIGHT_SHADOW
+					float3 lightDirectionWS = normalize(_LightPosition - positionWS);
+				#else
+					float3 lightDirectionWS = _LightDirection;
+				#endif
+
+				float4 positionCS = TransformWorldToHClip(ApplyShadowBias(positionWS, normalWS, lightDirectionWS));
+
+				//code for UNITY_REVERSED_Z is moved into Shadows.hlsl from 6000.0.22 and or higher
+				positionCS = ApplyShadowClamping(positionCS);
+
+				output.positionCS = positionCS;
+				output.positionWS = positionWS;
+				return output;
+			}
+
+			#if defined(ASE_TESSELLATION)
+			struct VertexControl
+			{
+				float4 positionOS : INTERNALTESSPOS;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				/*ase_vcontrol*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct TessellationFactors
+			{
+				float edge[3] : SV_TessFactor;
+				float inside : SV_InsideTessFactor;
+			};
+
+			VertexControl vert ( Attributes input )
+			{
+				VertexControl output;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				output.positionOS = input.positionOS;
+				output.normalOS = input.normalOS;
+				output.tangentOS = input.tangentOS;
+				/*ase_control_code:input=Attributes;output=VertexControl*/
+				return output;
+			}
+
+			TessellationFactors TessellationFunction (InputPatch<VertexControl,3> input)
+			{
+				TessellationFactors output;
+				float4 tf = 1;
+				float tessValue = /*ase_inline_begin*/_TessValue/*ase_inline_end*/; float tessMin = /*ase_inline_begin*/_TessMin/*ase_inline_end*/; float tessMax = /*ase_inline_begin*/_TessMax/*ase_inline_end*/;
+				float edgeLength = /*ase_inline_begin*/_TessEdgeLength/*ase_inline_end*/; float tessMaxDisp = /*ase_inline_begin*/_TessMaxDisp/*ase_inline_end*/;
+				#if defined(ASE_FIXED_TESSELLATION)
+				tf = FixedTess( tessValue );
+				#elif defined(ASE_DISTANCE_TESSELLATION)
+				tf = DistanceBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, tessValue, tessMin, tessMax, GetObjectToWorldMatrix(), _WorldSpaceCameraPos );
+				#elif defined(ASE_LENGTH_TESSELLATION)
+				tf = EdgeLengthBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams );
+				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+				tf = EdgeLengthBasedTessCull(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, tessMaxDisp, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
+				#endif
+				output.edge[0] = tf.x; output.edge[1] = tf.y; output.edge[2] = tf.z; output.inside = tf.w;
+				return output;
+			}
+
+			[domain("tri")]
+			[partitioning("fractional_odd")]
+			[outputtopology("triangle_cw")]
+			[patchconstantfunc("TessellationFunction")]
+			[outputcontrolpoints(3)]
+			VertexControl HullFunction(InputPatch<VertexControl, 3> patch, uint id : SV_OutputControlPointID)
+			{
+				return patch[id];
+			}
+
+			[domain("tri")]
+			PackedVaryings DomainFunction(TessellationFactors factors, OutputPatch<VertexControl, 3> patch, float3 bary : SV_DomainLocation)
+			{
+				Attributes output = (Attributes) 0;
+				output.positionOS = patch[0].positionOS * bary.x + patch[1].positionOS * bary.y + patch[2].positionOS * bary.z;
+				output.normalOS = patch[0].normalOS * bary.x + patch[1].normalOS * bary.y + patch[2].normalOS * bary.z;
+				output.tangentOS = patch[0].tangentOS * bary.x + patch[1].tangentOS * bary.y + patch[2].tangentOS * bary.z;
+				/*ase_domain_code:patch=VertexControl;output=Attributes;bary=SV_DomainLocation*/
+				#if defined(ASE_PHONG_TESSELLATION)
+				float3 pp[3];
+				for (int i = 0; i < 3; ++i)
+					pp[i] = output.positionOS.xyz - patch[i].normalOS * (dot(output.positionOS.xyz, patch[i].normalOS) - dot(patch[i].positionOS.xyz, patch[i].normalOS));
+				float phongStrength = /*ase_inline_begin*/_TessPhongStrength/*ase_inline_end*/;
+				output.positionOS.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * output.positionOS.xyz;
+				#endif
+				UNITY_TRANSFER_INSTANCE_ID(patch[0], output);
+				return VertexFunction(output);
+			}
+			#else
+			PackedVaryings vert ( Attributes input )
+			{
+				return VertexFunction( input );
+			}
+			#endif
+
+			half4 frag(	PackedVaryings input
+						#if defined( ASE_DEPTH_WRITE_ON )
+						,out float outputDepth : ASE_SV_DEPTH
+						#endif
+						/*ase_frag_input*/ ) : SV_Target
+			{
+				UNITY_SETUP_INSTANCE_ID( input );
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( input );
+
+				#if defined(MAIN_LIGHT_CALCULATE_SHADOWS) && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+					float4 shadowCoord = TransformWorldToShadowCoord(input.positionWS);
+				#else
+					float4 shadowCoord = float4(0, 0, 0, 0);
+				#endif
+
+				/*ase_local_var:wp*/float3 PositionWS = input.positionWS;
+				/*ase_local_var:rwp*/float3 PositionRWS = GetCameraRelativePositionWS( input.positionWS );
+				/*ase_local_var:sc*/float4 ShadowCoord = shadowCoord;
+				/*ase_local_var:spn*/float4 ScreenPosNorm = float4( GetNormalizedScreenSpaceUV( input.positionCS ), input.positionCS.zw );
+				/*ase_local_var:sp*/float4 ClipPos = ComputeClipSpacePosition( ScreenPosNorm.xy, input.positionCS.z ) * input.positionCS.w;
+				/*ase_local_var:spu*/float4 ScreenPos = ComputeScreenPos( ClipPos );
+
+				/*ase_frag_code:input=PackedVaryings*/
+
+				float Alpha = /*ase_frag_out:Alpha;Float;6;-1;_Alpha*/1/*end*/;
+				float AlphaClipThreshold = /*ase_frag_out:Alpha Clip Threshold;Float;7;-1;_AlphaClip*/0.5/*end*/;
+				float AlphaClipThresholdShadow = /*ase_frag_out:Alpha Clip Threshold Shadow;Float;16;-1;_AlphaClipShadow*/0.5/*end*/;
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					float DeviceDepth = /*ase_frag_out:Depth;Float;17;-1;_DepthValue*/input.positionCS.z/*end*/;
+				#endif
+
+				#if defined( _ALPHATEST_ON )
+					#if defined( _ALPHATEST_SHADOW_ON )
+						AlphaDiscard( Alpha, AlphaClipThresholdShadow );
+					#else
+						AlphaDiscard( Alpha, AlphaClipThreshold );
+					#endif
+				#endif
+
+				#if defined(LOD_FADE_CROSSFADE)
+					LODFadeCrossFade( input.positionCS );
+				#endif
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					outputDepth = DeviceDepth;
+				#endif
+
+				return 0;
+			}
+			ENDHLSL
+		}
+
+		/*ase_pass*/
+		Pass
+		{
+			/*ase_hide_pass*/
+			Name "DepthOnly"
+			Tags
+			{
+				"LightMode" = "DepthOnly"
+		    }
+
+			ZWrite On
+			ColorMask R
+			AlphaToMask Off
+
+			// To be able to tag stencil with disableAO information for forward
+            Stencil
+            {
+                WriteMask [_StencilWriteMaskDepth]
+                Ref [_StencilRefDepth]
+                Comp Always
+                Pass Replace
+            }
+
+			HLSLPROGRAM
+
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#if defined( _SPECULAR_SETUP ) && defined( ASE_LIGHTING_SIMPLE )
+				#if defined( _SPECULARHIGHLIGHTS_OFF )
+					#undef _SPECULAR_COLOR
+				#else
+					#define _SPECULAR_COLOR
+				#endif
+			#endif
+
+			#define SHADERPASS SHADERPASS_DEPTHONLY
+
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Texture.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Lit/Lighting.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/TextureStack.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
+
+			#if defined(LOD_FADE_CROSSFADE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+            #endif
+
+			/*ase_pragma*/
+
+			#if defined(ASE_EARLY_Z_DEPTH_OPTIMIZE) && (SHADER_TARGET >= 45)
+				#define ASE_SV_DEPTH SV_DepthLessEqual
+				#define ASE_SV_POSITION_QUALIFIERS linear noperspective centroid
+			#else
+				#define ASE_SV_DEPTH SV_Depth
+				#define ASE_SV_POSITION_QUALIFIERS
+			#endif
+
+			struct Attributes
+			{
+				float4 positionOS : POSITION;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				/*ase_vdata:p=p;n=n;t=t*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct PackedVaryings
+			{
+				ASE_SV_POSITION_QUALIFIERS float4 positionCS : SV_POSITION;
+				float3 positionWS : TEXCOORD0;
+				/*ase_interp(1,):sp=sp;wp=tc0.xyz*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+			#ifdef ASE_TRANSMISSION
+				float _TransmissionShadow;
+			#endif
+			#ifdef ASE_TRANSLUCENCY
+				float _TransStrength;
+				float _TransNormal;
+				float _TransScattering;
+				float _TransDirect;
+				float _TransAmbient;
+				float _TransShadow;
+			#endif
+			#ifdef ASE_TESSELLATION
+				float _TessPhongStrength;
+				float _TessValue;
+				float _TessMin;
+				float _TessMax;
+				float _TessEdgeLength;
+				float _TessMaxDisp;
+			#endif
+			CBUFFER_END
+
+			#ifdef SCENEPICKINGPASS
+				float4 _SelectionID;
+			#endif
+
+			#ifdef SCENESELECTIONPASS
+				int _ObjectId;
+				int _PassValue;
+			#endif
+
+			/*ase_globals*/
+
+			/*ase_funcs*/
+
+			PackedVaryings VertexFunction( Attributes input /*ase_vert_input*/ )
+			{
+				PackedVaryings output = (PackedVaryings)0;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+				/*ase_vert_code:input=Attributes;output=PackedVaryings*/
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					float3 defaultVertexValue = input.positionOS.xyz;
+				#else
+					float3 defaultVertexValue = float3(0, 0, 0);
+				#endif
+
+				float3 vertexValue = /*ase_vert_out:Vertex Offset;Float3;8;-1;_Vertex*/defaultVertexValue/*end*/;
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					input.positionOS.xyz = vertexValue;
+				#else
+					input.positionOS.xyz += vertexValue;
+				#endif
+
+				input.normalOS = /*ase_vert_out:Vertex Normal;Float3;10;-1;_Normal*/input.normalOS/*end*/;
+				input.tangentOS = /*ase_vert_out:Vertex Tangent;Float4;30;-1;_Tangent*/input.tangentOS/*end*/;
+
+				VertexPositionInputs vertexInput = GetVertexPositionInputs( input.positionOS.xyz );
+
+				output.positionCS = vertexInput.positionCS;
+				output.positionWS = vertexInput.positionWS;
+				return output;
+			}
+
+			#if defined(ASE_TESSELLATION)
+			struct VertexControl
+			{
+				float4 positionOS : INTERNALTESSPOS;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				/*ase_vcontrol*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct TessellationFactors
+			{
+				float edge[3] : SV_TessFactor;
+				float inside : SV_InsideTessFactor;
+			};
+
+			VertexControl vert ( Attributes input )
+			{
+				VertexControl output;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				output.positionOS = input.positionOS;
+				output.normalOS = input.normalOS;
+				output.tangentOS = input.tangentOS;
+				/*ase_control_code:input=Attributes;output=VertexControl*/
+				return output;
+			}
+
+			TessellationFactors TessellationFunction (InputPatch<VertexControl,3> input)
+			{
+				TessellationFactors output;
+				float4 tf = 1;
+				float tessValue = /*ase_inline_begin*/_TessValue/*ase_inline_end*/; float tessMin = /*ase_inline_begin*/_TessMin/*ase_inline_end*/; float tessMax = /*ase_inline_begin*/_TessMax/*ase_inline_end*/;
+				float edgeLength = /*ase_inline_begin*/_TessEdgeLength/*ase_inline_end*/; float tessMaxDisp = /*ase_inline_begin*/_TessMaxDisp/*ase_inline_end*/;
+				#if defined(ASE_FIXED_TESSELLATION)
+				tf = FixedTess( tessValue );
+				#elif defined(ASE_DISTANCE_TESSELLATION)
+				tf = DistanceBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, tessValue, tessMin, tessMax, GetObjectToWorldMatrix(), _WorldSpaceCameraPos );
+				#elif defined(ASE_LENGTH_TESSELLATION)
+				tf = EdgeLengthBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams );
+				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+				tf = EdgeLengthBasedTessCull(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, tessMaxDisp, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
+				#endif
+				output.edge[0] = tf.x; output.edge[1] = tf.y; output.edge[2] = tf.z; output.inside = tf.w;
+				return output;
+			}
+
+			[domain("tri")]
+			[partitioning("fractional_odd")]
+			[outputtopology("triangle_cw")]
+			[patchconstantfunc("TessellationFunction")]
+			[outputcontrolpoints(3)]
+			VertexControl HullFunction(InputPatch<VertexControl, 3> patch, uint id : SV_OutputControlPointID)
+			{
+				return patch[id];
+			}
+
+			[domain("tri")]
+			PackedVaryings DomainFunction(TessellationFactors factors, OutputPatch<VertexControl, 3> patch, float3 bary : SV_DomainLocation)
+			{
+				Attributes output = (Attributes) 0;
+				output.positionOS = patch[0].positionOS * bary.x + patch[1].positionOS * bary.y + patch[2].positionOS * bary.z;
+				output.normalOS = patch[0].normalOS * bary.x + patch[1].normalOS * bary.y + patch[2].normalOS * bary.z;
+				output.tangentOS = patch[0].tangentOS * bary.x + patch[1].tangentOS * bary.y + patch[2].tangentOS * bary.z;
+				/*ase_domain_code:patch=VertexControl;output=Attributes;bary=SV_DomainLocation*/
+				#if defined(ASE_PHONG_TESSELLATION)
+				float3 pp[3];
+				for (int i = 0; i < 3; ++i)
+					pp[i] = output.positionOS.xyz - patch[i].normalOS * (dot(output.positionOS.xyz, patch[i].normalOS) - dot(patch[i].positionOS.xyz, patch[i].normalOS));
+				float phongStrength = /*ase_inline_begin*/_TessPhongStrength/*ase_inline_end*/;
+				output.positionOS.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * output.positionOS.xyz;
+				#endif
+				UNITY_TRANSFER_INSTANCE_ID(patch[0], output);
+				return VertexFunction(output);
+			}
+			#else
+			PackedVaryings vert ( Attributes input )
+			{
+				return VertexFunction( input );
+			}
+			#endif
+
+			half4 frag(	PackedVaryings input
+						#if defined( ASE_DEPTH_WRITE_ON )
+						,out float outputDepth : ASE_SV_DEPTH
+						#endif
+						/*ase_frag_input*/ ) : SV_Target
+			{
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( input );
+
+				#if defined(MAIN_LIGHT_CALCULATE_SHADOWS) && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+					float4 shadowCoord = TransformWorldToShadowCoord(input.positionWS);
+				#else
+					float4 shadowCoord = float4(0, 0, 0, 0);
+				#endif
+
+				/*ase_local_var:wp*/float3 PositionWS = input.positionWS;
+				/*ase_local_var:rwp*/float3 PositionRWS = GetCameraRelativePositionWS( input.positionWS );
+				/*ase_local_var:sc*/float4 ShadowCoord = shadowCoord;
+				/*ase_local_var:spn*/float4 ScreenPosNorm = float4( GetNormalizedScreenSpaceUV( input.positionCS ), input.positionCS.zw );
+				/*ase_local_var:sp*/float4 ClipPos = ComputeClipSpacePosition( ScreenPosNorm.xy, input.positionCS.z ) * input.positionCS.w;
+				/*ase_local_var:spu*/float4 ScreenPos = ComputeScreenPos( ClipPos );
+
+				/*ase_frag_code:input=PackedVaryings*/
+
+				float Alpha = /*ase_frag_out:Alpha;Float;6;-1;_Alpha*/1/*end*/;
+				float AlphaClipThreshold = /*ase_frag_out:Alpha Clip Threshold;Float;7;-1;_AlphaClip*/0.5/*end*/;
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					float DeviceDepth = /*ase_frag_out:Depth;Float;17;-1;_DepthValue*/input.positionCS.z/*end*/;
+				#endif
+
+				#if defined( _ALPHATEST_ON )
+					AlphaDiscard( Alpha, AlphaClipThreshold );
+				#endif
+
+				#if defined(LOD_FADE_CROSSFADE)
+					LODFadeCrossFade( input.positionCS );
+				#endif
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					outputDepth = DeviceDepth;
+				#endif
+
+				return 0;
+			}
+			ENDHLSL
+		}
+
+		/*ase_pass*/
+		Pass
+		{
+			/*ase_hide_pass*/
+			Name "Meta"
+			Tags
+			{
+				"LightMode" = "Meta"
+		    }
+
+			Cull Off
+
+			HLSLPROGRAM
+			#pragma shader_feature EDITOR_VISUALIZATION
+
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#if defined( _SPECULAR_SETUP ) && defined( ASE_LIGHTING_SIMPLE )
+				#if defined( _SPECULARHIGHLIGHTS_OFF )
+					#undef _SPECULAR_COLOR
+				#else
+					#define _SPECULAR_COLOR
+				#endif
+			#endif
+
+			#define SHADERPASS SHADERPASS_META
+
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Texture.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Lit/Lighting.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/TextureStack.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/MetaInput.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
+
+			/*ase_pragma*/
+
+			struct Attributes
+			{
+				float4 positionOS : POSITION;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				float4 texcoord : TEXCOORD0;
+				float4 texcoord1 : TEXCOORD1;
+				float4 texcoord2 : TEXCOORD2;
+				/*ase_vdata:p=p;n=n;t=t;uv0=tc0;uv1=tc1;uv2=tc2*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct PackedVaryings
+			{
+				float4 positionCS : SV_POSITION;
+				float3 positionWS : TEXCOORD0;
+				#ifdef EDITOR_VISUALIZATION
+					float4 VizUV : TEXCOORD1;
+					float4 LightCoord : TEXCOORD2;
+				#endif
+				/*ase_interp(3,):sp=sp;wp=tc0.xyz*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+			#ifdef ASE_TRANSMISSION
+				float _TransmissionShadow;
+			#endif
+			#ifdef ASE_TRANSLUCENCY
+				float _TransStrength;
+				float _TransNormal;
+				float _TransScattering;
+				float _TransDirect;
+				float _TransAmbient;
+				float _TransShadow;
+			#endif
+			#ifdef ASE_TESSELLATION
+				float _TessPhongStrength;
+				float _TessValue;
+				float _TessMin;
+				float _TessMax;
+				float _TessEdgeLength;
+				float _TessMaxDisp;
+			#endif
+			CBUFFER_END
+
+			#ifdef SCENEPICKINGPASS
+				float4 _SelectionID;
+			#endif
+
+			#ifdef SCENESELECTIONPASS
+				int _ObjectId;
+				int _PassValue;
+			#endif
+
+			/*ase_globals*/
+
+			/*ase_funcs*/
+
+			PackedVaryings VertexFunction( Attributes input /*ase_vert_input*/ )
+			{
+				PackedVaryings output = (PackedVaryings)0;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+				/*ase_vert_code:input=Attributes;output=PackedVaryings*/
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					float3 defaultVertexValue = input.positionOS.xyz;
+				#else
+					float3 defaultVertexValue = float3(0, 0, 0);
+				#endif
+
+				float3 vertexValue = /*ase_vert_out:Vertex Offset;Float3;8;-1;_Vertex*/defaultVertexValue/*end*/;
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					input.positionOS.xyz = vertexValue;
+				#else
+					input.positionOS.xyz += vertexValue;
+				#endif
+
+				input.normalOS = /*ase_vert_out:Vertex Normal;Float3;10;-1;_Normal*/input.normalOS/*end*/;
+				input.tangentOS = /*ase_vert_out:Vertex Tangent;Float4;30;-1;_Tangent*/input.tangentOS/*end*/;
+
+				#ifdef EDITOR_VISUALIZATION
+					float2 VizUV = 0;
+					float4 LightCoord = 0;
+					UnityEditorVizData(input.positionOS.xyz, input.texcoord.xy, input.texcoord1.xy, input.texcoord2.xy, VizUV, LightCoord);
+					output.VizUV = float4(VizUV, 0, 0);
+					output.LightCoord = LightCoord;
+				#endif
+
+				output.positionCS = MetaVertexPosition( input.positionOS, input.texcoord1.xy, input.texcoord1.xy, unity_LightmapST, unity_DynamicLightmapST );
+				output.positionWS = TransformObjectToWorld( input.positionOS.xyz );
+				return output;
+			}
+
+			#if defined(ASE_TESSELLATION)
+			struct VertexControl
+			{
+				float4 positionOS : INTERNALTESSPOS;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				float4 texcoord : TEXCOORD0;
+				float4 texcoord1 : TEXCOORD1;
+				float4 texcoord2 : TEXCOORD2;
+				/*ase_vcontrol*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct TessellationFactors
+			{
+				float edge[3] : SV_TessFactor;
+				float inside : SV_InsideTessFactor;
+			};
+
+			VertexControl vert ( Attributes input )
+			{
+				VertexControl output;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				output.positionOS = input.positionOS;
+				output.normalOS = input.normalOS;
+				output.tangentOS = input.tangentOS;
+				output.texcoord = input.texcoord;
+				output.texcoord1 = input.texcoord1;
+				output.texcoord2 = input.texcoord2;
+				/*ase_control_code:input=Attributes;output=VertexControl*/
+				return output;
+			}
+
+			TessellationFactors TessellationFunction (InputPatch<VertexControl,3> input)
+			{
+				TessellationFactors output;
+				float4 tf = 1;
+				float tessValue = /*ase_inline_begin*/_TessValue/*ase_inline_end*/; float tessMin = /*ase_inline_begin*/_TessMin/*ase_inline_end*/; float tessMax = /*ase_inline_begin*/_TessMax/*ase_inline_end*/;
+				float edgeLength = /*ase_inline_begin*/_TessEdgeLength/*ase_inline_end*/; float tessMaxDisp = /*ase_inline_begin*/_TessMaxDisp/*ase_inline_end*/;
+				#if defined(ASE_FIXED_TESSELLATION)
+				tf = FixedTess( tessValue );
+				#elif defined(ASE_DISTANCE_TESSELLATION)
+				tf = DistanceBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, tessValue, tessMin, tessMax, GetObjectToWorldMatrix(), _WorldSpaceCameraPos );
+				#elif defined(ASE_LENGTH_TESSELLATION)
+				tf = EdgeLengthBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams );
+				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+				tf = EdgeLengthBasedTessCull(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, tessMaxDisp, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
+				#endif
+				output.edge[0] = tf.x; output.edge[1] = tf.y; output.edge[2] = tf.z; output.inside = tf.w;
+				return output;
+			}
+
+			[domain("tri")]
+			[partitioning("fractional_odd")]
+			[outputtopology("triangle_cw")]
+			[patchconstantfunc("TessellationFunction")]
+			[outputcontrolpoints(3)]
+			VertexControl HullFunction(InputPatch<VertexControl, 3> patch, uint id : SV_OutputControlPointID)
+			{
+				return patch[id];
+			}
+
+			[domain("tri")]
+			PackedVaryings DomainFunction(TessellationFactors factors, OutputPatch<VertexControl, 3> patch, float3 bary : SV_DomainLocation)
+			{
+				Attributes output = (Attributes) 0;
+				output.positionOS = patch[0].positionOS * bary.x + patch[1].positionOS * bary.y + patch[2].positionOS * bary.z;
+				output.normalOS = patch[0].normalOS * bary.x + patch[1].normalOS * bary.y + patch[2].normalOS * bary.z;
+				output.tangentOS = patch[0].tangentOS * bary.x + patch[1].tangentOS * bary.y + patch[2].tangentOS * bary.z;
+				output.texcoord = patch[0].texcoord * bary.x + patch[1].texcoord * bary.y + patch[2].texcoord * bary.z;
+				output.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
+				output.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
+				/*ase_domain_code:patch=VertexControl;output=Attributes;bary=SV_DomainLocation*/
+				#if defined(ASE_PHONG_TESSELLATION)
+				float3 pp[3];
+				for (int i = 0; i < 3; ++i)
+					pp[i] = output.positionOS.xyz - patch[i].normalOS * (dot(output.positionOS.xyz, patch[i].normalOS) - dot(patch[i].positionOS.xyz, patch[i].normalOS));
+				float phongStrength = /*ase_inline_begin*/_TessPhongStrength/*ase_inline_end*/;
+				output.positionOS.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * output.positionOS.xyz;
+				#endif
+				UNITY_TRANSFER_INSTANCE_ID(patch[0], output);
+				return VertexFunction(output);
+			}
+			#else
+			PackedVaryings vert ( Attributes input )
+			{
+				return VertexFunction( input );
+			}
+			#endif
+
+			half4 frag(PackedVaryings input /*ase_frag_input*/ ) : SV_Target
+			{
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( input );
+
+				#if defined(MAIN_LIGHT_CALCULATE_SHADOWS) && defined(ASE_NEEDS_FRAG_SHADOWCOORDS)
+					float4 shadowCoord = TransformWorldToShadowCoord(input.positionWS);
+				#else
+					float4 shadowCoord = float4(0, 0, 0, 0);
+				#endif
+
+				/*ase_local_var:wp*/float3 PositionWS = input.positionWS;
+				/*ase_local_var:rwp*/float3 PositionRWS = GetCameraRelativePositionWS( input.positionWS );
+				/*ase_local_var:sc*/float4 ShadowCoord = shadowCoord;
+
+				/*ase_frag_code:input=PackedVaryings*/
+
+				float3 BaseColor = /*ase_frag_out:Base Color;Float3;0;-1;_BaseColor*/float3(0.5, 0.5, 0.5)/*end*/;
+				float3 Emission = /*ase_frag_out:Emission;Float3;2;-1;_Emission*/0/*end*/;
+				float Alpha = /*ase_frag_out:Alpha;Float;6;-1;_Alpha*/1/*end*/;
+				float AlphaClipThreshold = /*ase_frag_out:Alpha Clip Threshold;Float;7;-1;_AlphaClip*/0.5/*end*/;
+
+				#if defined( _ALPHATEST_ON )
+					AlphaDiscard( Alpha, AlphaClipThreshold );
+				#endif
+
+				MetaInput metaInput = (MetaInput)0;
+				metaInput.Albedo = BaseColor;
+				metaInput.Emission = Emission;
+				#ifdef EDITOR_VISUALIZATION
+					metaInput.VizUV = input.VizUV.xy;
+					metaInput.LightCoord = input.LightCoord;
+				#endif
+
+				return UnityMetaFragment(metaInput);
+			}
+			ENDHLSL
+		}
+
+		/*ase_pass*/
+		Pass
+		{
+			/*ase_hide_pass:SyncP*/
+			Name "GBuffer"
+			Tags
+			{
+				"LightMode" = "UniversalGBuffer"
+		    }
+
+			Blend One Zero
+			ZWrite On
+			ZTest LEqual
+			Offset 0,0
+			ColorMask RGBA
+			/*ase_stencil*/
+
+			HLSLPROGRAM
+
+			// Deferred Rendering Path does not support the OpenGL-based graphics API:
+			// Desktop OpenGL, OpenGL ES 3.0, WebGL 2.0.
+			#pragma exclude_renderers gles3 glcore
+
+			#pragma multi_compile _ _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE _MAIN_LIGHT_SHADOWS_SCREEN
+			#pragma multi_compile _ EVALUATE_SH_MIXED EVALUATE_SH_VERTEX
+			#pragma multi_compile_fragment _ _REFLECTION_PROBE_BLENDING
+			#pragma multi_compile_fragment _ _REFLECTION_PROBE_BOX_PROJECTION
+			#pragma multi_compile_fragment _ _SHADOWS_SOFT _SHADOWS_SOFT_LOW _SHADOWS_SOFT_MEDIUM _SHADOWS_SOFT_HIGH
+			#pragma multi_compile_fragment _ _SCREEN_SPACE_IRRADIANCE
+			#pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+			#pragma multi_compile_fragment _ _GBUFFER_NORMALS_OCT
+			#pragma multi_compile_fragment _ _RENDER_PASS_ENABLED
+			#pragma multi_compile _ _CLUSTER_LIGHT_LOOP
+
+			#pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
+			#pragma multi_compile _ _MIXED_LIGHTING_SUBTRACTIVE
+			#pragma multi_compile _ SHADOWS_SHADOWMASK
+			#pragma multi_compile _ DIRLIGHTMAP_COMBINED
+			#pragma multi_compile _ USE_LEGACY_LIGHTMAPS
+			#pragma multi_compile _ LIGHTMAP_ON
+			#pragma multi_compile_fragment _ LIGHTMAP_BICUBIC_SAMPLING
+			#pragma multi_compile_fragment _ REFLECTION_PROBE_ROTATION
+			#pragma multi_compile _ DYNAMICLIGHTMAP_ON
+
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#if defined( _SPECULAR_SETUP ) && defined( ASE_LIGHTING_SIMPLE )
+				#if defined( _SPECULARHIGHLIGHTS_OFF )
+					#undef _SPECULAR_COLOR
+				#else
+					#define _SPECULAR_COLOR
+				#endif
+			#endif
+
+			#define SHADERPASS SHADERPASS_GBUFFER
+
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Texture.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Lit/Lighting.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/TextureStack.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DBuffer.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
+
+			#if defined(LOD_FADE_CROSSFADE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+            #endif
+
+			#if defined( UNITY_INSTANCING_ENABLED ) && defined( ASE_INSTANCED_TERRAIN ) && ( defined(_TERRAIN_INSTANCED_PERPIXEL_NORMAL) || defined(_INSTANCEDTERRAINNORMALS_PIXEL) )
+				#define ENABLE_TERRAIN_PERPIXEL_NORMAL
+			#endif
+
+			/*ase_pragma*/
+
+			#if defined(ASE_EARLY_Z_DEPTH_OPTIMIZE) && (SHADER_TARGET >= 45)
+				#define ASE_SV_DEPTH SV_DepthLessEqual
+				#define ASE_SV_POSITION_QUALIFIERS linear noperspective centroid
+			#else
+				#define ASE_SV_DEPTH SV_Depth
+				#define ASE_SV_POSITION_QUALIFIERS
+			#endif
+
+			struct Attributes
+			{
+				float4 positionOS : POSITION;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				float4 texcoord : TEXCOORD0;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					float4 texcoord1 : TEXCOORD1;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					float4 texcoord2 : TEXCOORD2;
+				#endif
+				/*ase_vdata:p=p;n=n;t=t;uv0=tc0;uv1=tc1;uv2=tc2*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct PackedVaryings
+			{
+				ASE_SV_POSITION_QUALIFIERS float4 positionCS : SV_POSITION;
+				float3 positionWS : TEXCOORD0;
+				half3 normalWS : TEXCOORD1;
+				float4 tangentWS : TEXCOORD2; // holds terrainUV ifdef ENABLE_TERRAIN_PERPIXEL_NORMAL
+				float4 lightmapUVOrVertexSH : TEXCOORD3;
+				#if defined(ASE_FOG) || defined(_ADDITIONAL_LIGHTS_VERTEX)
+					half4 fogFactorAndVertexLight : TEXCOORD4;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON)
+					float2 dynamicLightmapUV : TEXCOORD5;
+				#endif
+				#if defined(USE_APV_PROBE_OCCLUSION)
+					float4 probeOcclusion : TEXCOORD6;
+				#endif
+				/*ase_interp(7,):sp=sp;wp=tc0.xyz;wn.xyz=tc1.xyz;wt.xyz=tc2.xyz*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+			#ifdef ASE_TRANSMISSION
+				float _TransmissionShadow;
+			#endif
+			#ifdef ASE_TRANSLUCENCY
+				float _TransStrength;
+				float _TransNormal;
+				float _TransScattering;
+				float _TransDirect;
+				float _TransAmbient;
+				float _TransShadow;
+			#endif
+			#ifdef ASE_TESSELLATION
+				float _TessPhongStrength;
+				float _TessValue;
+				float _TessMin;
+				float _TessMax;
+				float _TessEdgeLength;
+				float _TessMaxDisp;
+			#endif
+			CBUFFER_END
+
+			#ifdef SCENEPICKINGPASS
+				float4 _SelectionID;
+			#endif
+
+			#ifdef SCENESELECTIONPASS
+				int _ObjectId;
+				int _PassValue;
+			#endif
+
+			/*ase_globals*/
+
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/GBufferOutput.hlsl"
+
+			/*ase_funcs*/
+
+			PackedVaryings VertexFunction( Attributes input /*ase_vert_input*/ )
+			{
+				PackedVaryings output = (PackedVaryings)0;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+				/*ase_vert_code:input=Attributes;output=PackedVaryings*/
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					float3 defaultVertexValue = input.positionOS.xyz;
+				#else
+					float3 defaultVertexValue = float3(0, 0, 0);
+				#endif
+
+				float3 vertexValue = /*ase_vert_out:Vertex Offset;Float3;8;-1;_Vertex*/defaultVertexValue/*end*/;
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					input.positionOS.xyz = vertexValue;
+				#else
+					input.positionOS.xyz += vertexValue;
+				#endif
+
+				input.normalOS = /*ase_vert_out:Vertex Normal;Float3;10;-1;_Normal*/input.normalOS/*end*/;
+				input.tangentOS = /*ase_vert_out:Vertex Tangent;Float4;30;-1;_Tangent*/input.tangentOS/*end*/;
+
+				VertexPositionInputs vertexInput = GetVertexPositionInputs( input.positionOS.xyz );
+				VertexNormalInputs normalInput = GetVertexNormalInputs( input.normalOS, input.tangentOS );
+
+				OUTPUT_LIGHTMAP_UV(input.texcoord1, unity_LightmapST, output.lightmapUVOrVertexSH.xy);
+				#if defined(DYNAMICLIGHTMAP_ON)
+					output.dynamicLightmapUV.xy = input.texcoord2.xy * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
+				#endif
+				OUTPUT_SH4(vertexInput.positionWS, normalInput.normalWS.xyz, GetWorldSpaceNormalizeViewDir(vertexInput.positionWS), output.lightmapUVOrVertexSH.xyz, output.probeOcclusion);
+
+				#if defined(ASE_FOG) || defined(_ADDITIONAL_LIGHTS_VERTEX)
+					output.fogFactorAndVertexLight = 0;
+					#if defined(ASE_FOG) && !defined(_FOG_FRAGMENT)
+						// @diogo: no fog applied in GBuffer
+					#endif
+					#ifdef _ADDITIONAL_LIGHTS_VERTEX
+						half3 vertexLight = VertexLighting( vertexInput.positionWS, normalInput.normalWS );
+						output.fogFactorAndVertexLight.yzw = vertexLight;
+					#endif
+				#endif
+
+				output.positionCS = vertexInput.positionCS;
+				output.positionWS = vertexInput.positionWS;
+				output.normalWS = normalInput.normalWS;
+				output.tangentWS = float4( normalInput.tangentWS, ( input.tangentOS.w > 0.0 ? 1.0 : -1.0 ) * GetOddNegativeScale() );
+
+				#if defined( ENABLE_TERRAIN_PERPIXEL_NORMAL )
+					output.tangentWS.zw = input.texcoord.xy;
+					output.tangentWS.xy = input.texcoord.xy * unity_LightmapST.xy + unity_LightmapST.zw;
+				#endif
+				return output;
+			}
+
+			#if defined(ASE_TESSELLATION)
+			struct VertexControl
+			{
+				float4 positionOS : INTERNALTESSPOS;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				float4 texcoord : TEXCOORD0;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					float4 texcoord1 : TEXCOORD1;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					float4 texcoord2 : TEXCOORD2;
+				#endif
+				/*ase_vcontrol*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct TessellationFactors
+			{
+				float edge[3] : SV_TessFactor;
+				float inside : SV_InsideTessFactor;
+			};
+
+			VertexControl vert ( Attributes input )
+			{
+				VertexControl output;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				output.positionOS = input.positionOS;
+				output.normalOS = input.normalOS;
+				output.tangentOS = input.tangentOS;
+				output.texcoord = input.texcoord;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					output.texcoord1 = input.texcoord1;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					output.texcoord2 = input.texcoord2;
+				#endif
+				/*ase_control_code:input=Attributes;output=VertexControl*/
+				return output;
+			}
+
+			TessellationFactors TessellationFunction (InputPatch<VertexControl,3> input)
+			{
+				TessellationFactors output;
+				float4 tf = 1;
+				float tessValue = /*ase_inline_begin*/_TessValue/*ase_inline_end*/; float tessMin = /*ase_inline_begin*/_TessMin/*ase_inline_end*/; float tessMax = /*ase_inline_begin*/_TessMax/*ase_inline_end*/;
+				float edgeLength = /*ase_inline_begin*/_TessEdgeLength/*ase_inline_end*/; float tessMaxDisp = /*ase_inline_begin*/_TessMaxDisp/*ase_inline_end*/;
+				#if defined(ASE_FIXED_TESSELLATION)
+				tf = FixedTess( tessValue );
+				#elif defined(ASE_DISTANCE_TESSELLATION)
+				tf = DistanceBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, tessValue, tessMin, tessMax, GetObjectToWorldMatrix(), _WorldSpaceCameraPos );
+				#elif defined(ASE_LENGTH_TESSELLATION)
+				tf = EdgeLengthBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams );
+				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+				tf = EdgeLengthBasedTessCull(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, tessMaxDisp, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
+				#endif
+				output.edge[0] = tf.x; output.edge[1] = tf.y; output.edge[2] = tf.z; output.inside = tf.w;
+				return output;
+			}
+
+			[domain("tri")]
+			[partitioning("fractional_odd")]
+			[outputtopology("triangle_cw")]
+			[patchconstantfunc("TessellationFunction")]
+			[outputcontrolpoints(3)]
+			VertexControl HullFunction(InputPatch<VertexControl, 3> patch, uint id : SV_OutputControlPointID)
+			{
+				return patch[id];
+			}
+
+			[domain("tri")]
+			PackedVaryings DomainFunction(TessellationFactors factors, OutputPatch<VertexControl, 3> patch, float3 bary : SV_DomainLocation)
+			{
+				Attributes output = (Attributes) 0;
+				output.positionOS = patch[0].positionOS * bary.x + patch[1].positionOS * bary.y + patch[2].positionOS * bary.z;
+				output.normalOS = patch[0].normalOS * bary.x + patch[1].normalOS * bary.y + patch[2].normalOS * bary.z;
+				output.tangentOS = patch[0].tangentOS * bary.x + patch[1].tangentOS * bary.y + patch[2].tangentOS * bary.z;
+				output.texcoord = patch[0].texcoord * bary.x + patch[1].texcoord * bary.y + patch[2].texcoord * bary.z;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					output.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					output.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
+				#endif
+				/*ase_domain_code:patch=VertexControl;output=Attributes;bary=SV_DomainLocation*/
+				#if defined(ASE_PHONG_TESSELLATION)
+				float3 pp[3];
+				for (int i = 0; i < 3; ++i)
+					pp[i] = output.positionOS.xyz - patch[i].normalOS * (dot(output.positionOS.xyz, patch[i].normalOS) - dot(patch[i].positionOS.xyz, patch[i].normalOS));
+				float phongStrength = /*ase_inline_begin*/_TessPhongStrength/*ase_inline_end*/;
+				output.positionOS.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * output.positionOS.xyz;
+				#endif
+				UNITY_TRANSFER_INSTANCE_ID(patch[0], output);
+				return VertexFunction(output);
+			}
+			#else
+			PackedVaryings vert ( Attributes input )
+			{
+				return VertexFunction( input );
+			}
+			#endif
+
+			GBufferFragOutput frag ( PackedVaryings input
+								#if defined( ASE_DEPTH_WRITE_ON )
+								,out float outputDepth : ASE_SV_DEPTH
+								#endif
+								/*ase_frag_input*/ )
+			{
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+				#if defined(LOD_FADE_CROSSFADE)
+					LODFadeCrossFade( input.positionCS );
+				#endif
+
+				#if defined(MAIN_LIGHT_CALCULATE_SHADOWS)
+					float4 shadowCoord = TransformWorldToShadowCoord( input.positionWS );
+				#else
+					float4 shadowCoord = float4(0, 0, 0, 0);
+				#endif
+
+				// @diogo: mikktspace compliant
+				float renormFactor = 1.0 / max( FLT_MIN, length( input.normalWS ) );
+
+				/*ase_local_var:wp*/float3 PositionWS = input.positionWS;
+				/*ase_local_var:rwp*/float3 PositionRWS = GetCameraRelativePositionWS( PositionWS );
+				/*ase_local_var:wvd*/float3 ViewDirWS = GetWorldSpaceNormalizeViewDir( PositionWS );
+				/*ase_local_var:sc*/float4 ShadowCoord = shadowCoord;
+				/*ase_local_var:spn*/float4 ScreenPosNorm = float4( GetNormalizedScreenSpaceUV( input.positionCS ), input.positionCS.zw );
+				/*ase_local_var:sp*/float4 ClipPos = ComputeClipSpacePosition( ScreenPosNorm.xy, input.positionCS.z ) * input.positionCS.w;
+				/*ase_local_var:spu*/float4 ScreenPos = ComputeScreenPos( ClipPos );
+				/*ase_local_var:wt*/float3 TangentWS = input.tangentWS.xyz * renormFactor;
+				/*ase_local_var:wbt*/float3 BitangentWS = cross( input.normalWS, input.tangentWS.xyz ) * input.tangentWS.w * renormFactor;
+				/*ase_local_var:wn*/float3 NormalWS = input.normalWS * renormFactor;
+
+				#if defined( ENABLE_TERRAIN_PERPIXEL_NORMAL )
+					float2 sampleCoords = (input.tangentWS.zw / _TerrainHeightmapRecipSize.zw + 0.5f) * _TerrainHeightmapRecipSize.xy;
+					NormalWS = TransformObjectToWorldNormal(normalize(SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_TerrainNormalmapTexture, sampleCoords).rgb * 2 - 1));
+					TangentWS = -cross(GetObjectToWorldMatrix()._13_23_33, NormalWS);
+					BitangentWS = cross(NormalWS, -TangentWS);
+				#endif
+
+				/*ase_frag_code:input=PackedVaryings*/
+
+				float3 BaseColor = /*ase_frag_out:Base Color;Float3;0;-1;_BaseColor*/float3(0.5, 0.5, 0.5)/*end*/;
+				float3 Normal = /*ase_frag_out:Normal;Float3;1;-1;_FragNormal*/float3(0, 0, 1)/*end*/;
+				float3 Specular = /*ase_frag_out:Specular;Float3;9;-1;_Specular*/0.5/*end*/;
+				float Metallic = /*ase_frag_out:Metallic;Float;3;-1;_Metallic*/0/*end*/;
+				float Smoothness = /*ase_frag_out:Smoothness;Float;4;-1;_Smoothness*/0.5/*end*/;
+				float Occlusion = /*ase_frag_out:Occlusion;Float;5;-1;_Occlusion*/1/*end*/;
+				float3 Emission = /*ase_frag_out:Emission;Float3;2;-1;_Emission*/0/*end*/;
+				float Alpha = /*ase_frag_out:Alpha;Float;6;-1;_Alpha*/1/*end*/;
+				float AlphaClipThreshold = /*ase_frag_out:Alpha Clip Threshold;Float;7;-1;_AlphaClip*/0.5/*end*/;
+				float AlphaClipThresholdShadow = /*ase_frag_out:Alpha Clip Threshold Shadow;Float;16;-1;_AlphaClipShadow*/0.5/*end*/;
+				float3 BakedGI = /*ase_frag_out:Baked GI;Float3;11;-1;_BakedGI*/0/*end*/;
+				float3 RefractionColor = /*ase_frag_out:Refraction Color;Float3;12;-1;_RefractionColor*/1/*end*/;
+				float RefractionIndex = /*ase_frag_out:Refraction Index;Float;13;-1;_RefractionIndex*/1/*end*/;
+				float3 Transmission = /*ase_frag_out:Transmission;Float3;14;-1;_Transmission*/1/*end*/;
+				float3 Translucency = /*ase_frag_out:Translucency;Float3;15;-1;_Translucency*/1/*end*/;
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					float DeviceDepth = /*ase_frag_out:Depth;Float;17;-1;_DepthValue*/ClipPos.z/*end*/;
+				#endif
+
+				#if defined( _ALPHATEST_ON )
+					AlphaDiscard( Alpha, AlphaClipThreshold );
+				#endif
+
+				#if defined(MAIN_LIGHT_CALCULATE_SHADOWS) && defined(ASE_CHANGES_WORLD_POS)
+					ShadowCoord = TransformWorldToShadowCoord( PositionWS );
+				#endif
+
+				InputData inputData = (InputData)0;
+				inputData.positionWS = PositionWS;
+				inputData.positionCS = float4( input.positionCS.xy, ClipPos.zw / ClipPos.w );
+				inputData.normalizedScreenSpaceUV = ScreenPosNorm.xy;
+				inputData.shadowCoord = ShadowCoord;
+
+				#ifdef _NORMALMAP
+					#if _NORMAL_DROPOFF_TS
+						inputData.normalWS = TransformTangentToWorld(Normal, half3x3( TangentWS, BitangentWS, NormalWS ));
+					#elif _NORMAL_DROPOFF_OS
+						inputData.normalWS = TransformObjectToWorldNormal(Normal);
+					#elif _NORMAL_DROPOFF_WS
+						inputData.normalWS = Normal;
+					#endif
+				#else
+					inputData.normalWS = NormalWS;
+				#endif
+
+				inputData.normalWS = NormalizeNormalPerPixel(inputData.normalWS);
+				inputData.viewDirectionWS = SafeNormalize( ViewDirWS );
+
+				#ifdef ASE_FOG
+					// @diogo: no fog applied in GBuffer
+				#endif
+				#ifdef _ADDITIONAL_LIGHTS_VERTEX
+					inputData.vertexLighting = input.fogFactorAndVertexLight.yzw;
+				#endif
+
+				#if defined( ENABLE_TERRAIN_PERPIXEL_NORMAL )
+					float3 SH = SampleSH(inputData.normalWS.xyz);
+				#else
+					float3 SH = input.lightmapUVOrVertexSH.xyz;
+				#endif
+
+				#if defined(_SCREEN_SPACE_IRRADIANCE)
+					inputData.bakedGI = SAMPLE_GI(_ScreenSpaceIrradiance, input.positionCS.xy);
+				#elif defined(DYNAMICLIGHTMAP_ON)
+					inputData.bakedGI = SAMPLE_GI(input.lightmapUVOrVertexSH.xy, input.dynamicLightmapUV.xy, SH, inputData.normalWS);
+					inputData.shadowMask = SAMPLE_SHADOWMASK(input.lightmapUVOrVertexSH.xy);
+				#elif !defined(LIGHTMAP_ON) && (defined(PROBE_VOLUMES_L1) || defined(PROBE_VOLUMES_L2))
+					inputData.bakedGI = SAMPLE_GI(SH,
+						GetAbsolutePositionWS(inputData.positionWS),
+						inputData.normalWS,
+						inputData.viewDirectionWS,
+						input.positionCS.xy,
+						input.probeOcclusion,
+						inputData.shadowMask);
+				#else
+					inputData.bakedGI = SAMPLE_GI(input.lightmapUVOrVertexSH.xy, SH, inputData.normalWS);
+					inputData.shadowMask = SAMPLE_SHADOWMASK(input.lightmapUVOrVertexSH.xy);
+				#endif
+
+				#ifdef ASE_BAKEDGI
+					inputData.bakedGI = BakedGI;
+				#endif
+
+				#if defined(DEBUG_DISPLAY)
+					#if defined(DYNAMICLIGHTMAP_ON)
+						inputData.dynamicLightmapUV = input.dynamicLightmapUV.xy;
+						#endif
+					#if defined(LIGHTMAP_ON)
+						inputData.staticLightmapUV = input.lightmapUVOrVertexSH.xy;
+					#else
+						inputData.vertexSH = SH;
+					#endif
+					#if defined(USE_APV_PROBE_OCCLUSION)
+						inputData.probeOcclusion = input.probeOcclusion;
+					#endif
+				#endif
+
+				#ifdef _DBUFFER
+					ApplyDecal(input.positionCS,
+						BaseColor,
+						Specular,
+						inputData.normalWS,
+						Metallic,
+						Occlusion,
+						Smoothness);
+				#endif
+
+				BRDFData brdfData;
+				InitializeBRDFData(BaseColor, Metallic, Specular, Smoothness, Alpha, brdfData);
+
+				Light mainLight = IllusionGetMainLight(inputData.shadowCoord, inputData.positionWS, inputData.normalWS, inputData.shadowMask);
+				half4 color;
+				MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI, inputData.shadowMask);
+
+				color.rgb = GlobalIllumination(brdfData, (BRDFData)0, 0,
+                              inputData.bakedGI, Occlusion, inputData.positionWS,
+                              inputData.normalWS, inputData.viewDirectionWS, inputData.normalizedScreenSpaceUV);
+
+				color.a = Alpha;
+
+				#ifdef ASE_FINAL_COLOR_ALPHA_MULTIPLY
+					color.rgb *= color.a;
+				#endif
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					outputDepth = DeviceDepth;
+				#endif
+
+				return PackGBuffersBRDFData(brdfData, inputData, Smoothness, Emission + color.rgb, Occlusion);
+			}
+
+			ENDHLSL
+		}
+
+		/*ase_pass*/
+		Pass
+		{
+			/*ase_hide_pass*/
+			Name "MotionVectors"
+			Tags
+			{
+				"LightMode" = "MotionVectors"
+			}
+
+			ColorMask RG
+
+			HLSLPROGRAM
+
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#if defined( _SPECULAR_SETUP ) && defined( ASE_LIGHTING_SIMPLE )
+				#if defined( _SPECULARHIGHLIGHTS_OFF )
+					#undef _SPECULAR_COLOR
+				#else
+					#define _SPECULAR_COLOR
+				#endif
+			#endif
+
+            #define SHADERPASS SHADERPASS_MOTION_VECTORS
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+		    #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
+		    #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Texture.hlsl"
+		    #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+		    #include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Lit/Lighting.hlsl"
+		    #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
+		    #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/TextureStack.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+		    #include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
+		    #include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
+
+			#if defined(LOD_FADE_CROSSFADE)
+				#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+			#endif
+
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/MotionVectorsCommon.hlsl"
+
+			/*ase_pragma*/
+
+			#if defined(ASE_EARLY_Z_DEPTH_OPTIMIZE) && (SHADER_TARGET >= 45)
+				#define ASE_SV_DEPTH SV_DepthLessEqual
+				#define ASE_SV_POSITION_QUALIFIERS linear noperspective centroid
+			#else
+				#define ASE_SV_DEPTH SV_Depth
+				#define ASE_SV_POSITION_QUALIFIERS
+			#endif
+
+			struct Attributes
+			{
+				float4 positionOS : POSITION;
+				float3 positionOld : TEXCOORD4;
+				#if _ADD_PRECOMPUTED_VELOCITY
+					float3 alembicMotionVector : TEXCOORD5;
+				#endif
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				/*ase_vdata:p=p;n=n;t=t;uv4=tc4;uv5=tc5*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct PackedVaryings
+			{
+				float4 positionCS : SV_POSITION;
+				float4 positionCSNoJitter : TEXCOORD0;
+				float4 previousPositionCSNoJitter : TEXCOORD1;
+				float3 positionWS : TEXCOORD2;
+				/*ase_interp(3,):sp=sp.xyzw*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+			#ifdef ASE_TRANSMISSION
+				float _TransmissionShadow;
+			#endif
+			#ifdef ASE_TRANSLUCENCY
+				float _TransStrength;
+				float _TransNormal;
+				float _TransScattering;
+				float _TransDirect;
+				float _TransAmbient;
+				float _TransShadow;
+			#endif
+			#ifdef ASE_TESSELLATION
+				float _TessPhongStrength;
+				float _TessValue;
+				float _TessMin;
+				float _TessMax;
+				float _TessEdgeLength;
+				float _TessMaxDisp;
+			#endif
+			CBUFFER_END
+
+			#ifdef SCENEPICKINGPASS
+				float4 _SelectionID;
+			#endif
+
+			#ifdef SCENESELECTIONPASS
+				int _ObjectId;
+				int _PassValue;
+			#endif
+
+			/*ase_globals*/
+
+			/*ase_funcs*/
+
+			PackedVaryings VertexFunction( Attributes input /*ase_vert_input*/ )
+			{
+				PackedVaryings output = (PackedVaryings)0;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+				/*ase_vert_code:input=Attributes;output=PackedVaryings*/
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					float3 defaultVertexValue = input.positionOS.xyz;
+				#else
+					float3 defaultVertexValue = float3(0, 0, 0);
+				#endif
+
+				float3 vertexValue = /*ase_vert_out:Vertex Offset;Float3;8;-1;_Vertex*/defaultVertexValue/*end*/;
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					input.positionOS.xyz = vertexValue;
+				#else
+					input.positionOS.xyz += vertexValue;
+				#endif
+
+				VertexPositionInputs vertexInput = GetVertexPositionInputs( input.positionOS.xyz );
+
+				#if defined(APPLICATION_SPACE_WARP_MOTION)
+					output.positionCSNoJitter = mul(_NonJitteredViewProjMatrix, mul(UNITY_MATRIX_M, input.positionOS));
+					output.positionCS = output.positionCSNoJitter;
+				#else
+					output.positionCS = vertexInput.positionCS;
+					output.positionCSNoJitter = mul(_NonJitteredViewProjMatrix, mul(UNITY_MATRIX_M, input.positionOS));
+				#endif
+
+				float4 prevPos = ( unity_MotionVectorsParams.x == 1 ) ? float4( input.positionOld, 1 ) : input.positionOS;
+
+				#if _ADD_PRECOMPUTED_VELOCITY
+					prevPos = prevPos - float4(input.alembicMotionVector, 0);
+				#endif
+
+				output.previousPositionCSNoJitter = mul( _PrevViewProjMatrix, mul( UNITY_PREV_MATRIX_M, prevPos ) );
+
+				output.positionWS = vertexInput.positionWS;
+
+				// removed in ObjectMotionVectors.hlsl found in unity 6000.0.23 and higher
+				//ApplyMotionVectorZBias( output.positionCS );
+				return output;
+			}
+
+			PackedVaryings vert ( Attributes input )
+			{
+				return VertexFunction( input );
+			}
+
+			half4 frag(	PackedVaryings input
+				#if defined( ASE_DEPTH_WRITE_ON )
+				,out float outputDepth : ASE_SV_DEPTH
+				#endif
+				/*ase_frag_input*/ ) : SV_Target
+			{
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( input );
+
+				/*ase_local_var:wp*/float3 PositionWS = input.positionWS;
+				/*ase_local_var:rwp*/float3 PositionRWS = GetCameraRelativePositionWS( PositionWS );
+				/*ase_local_var:spn*/float4 ScreenPosNorm = float4( GetNormalizedScreenSpaceUV( input.positionCS ), input.positionCS.zw );
+				/*ase_local_var:sp*/float4 ClipPos = ComputeClipSpacePosition( ScreenPosNorm.xy, input.positionCS.z ) * input.positionCS.w;
+
+				/*ase_frag_code:input=PackedVaryings*/
+
+				float Alpha = /*ase_frag_out:Alpha;Float;6;-1;_Alpha*/1/*end*/;
+				float AlphaClipThreshold = /*ase_frag_out:Alpha Clip Threshold;Float;7;-1;_AlphaClip*/0.5/*end*/;
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					float DeviceDepth = /*ase_frag_out:Depth;Float;17;-1;_DepthValue*/input.positionCS.z/*end*/;
+				#endif
+
+				#ifdef _ALPHATEST_ON
+					clip(Alpha - AlphaClipThreshold);
+				#endif
+
+				#if defined(ASE_CHANGES_WORLD_POS)
+					float3 positionOS = mul( GetWorldToObjectMatrix(),  float4( PositionWS, 1.0 ) ).xyz;
+					float3 previousPositionWS = mul( GetPrevObjectToWorldMatrix(),  float4( positionOS, 1.0 ) ).xyz;
+					input.positionCSNoJitter = mul( _NonJitteredViewProjMatrix, float4( PositionWS, 1.0 ) );
+					input.previousPositionCSNoJitter = mul( _PrevViewProjMatrix, float4( previousPositionWS, 1.0 ) );
+				#endif
+
+				#if defined(LOD_FADE_CROSSFADE)
+					LODFadeCrossFade( input.positionCS );
+				#endif
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					outputDepth = DeviceDepth;
+				#endif
+
+				#if defined(APPLICATION_SPACE_WARP_MOTION)
+					return float4( CalcAswNdcMotionVectorFromCsPositions( input.positionCSNoJitter, input.previousPositionCSNoJitter ), 1 );
+				#else
+					return float4( CalcNdcMotionVectorFromCsPositions( input.positionCSNoJitter, input.previousPositionCSNoJitter ), 0, 0 );
+				#endif
+			}
+			ENDHLSL
+		}
+
+		/*ase_pass*/
+		Pass
+		{
+			/*ase_hide_pass*/
+			Name "XRMotionVectors"
+			Tags
+			{
+				"LightMode" = "XRMotionVectors"
+			}
+
+			ColorMask RGBA
+
+			Stencil
+			{
+				WriteMask 1
+				Ref 1
+				Comp Always
+				Pass Replace
+			}
+
+			HLSLPROGRAM
+
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#define APPLICATION_SPACE_WARP_MOTION 1
+
+			#if defined( _SPECULAR_SETUP ) && defined( ASE_LIGHTING_SIMPLE )
+				#if defined( _SPECULARHIGHLIGHTS_OFF )
+					#undef _SPECULAR_COLOR
+				#else
+					#define _SPECULAR_COLOR
+				#endif
+			#endif
+
+            #define SHADERPASS SHADERPASS_MOTION_VECTORS
+
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+		    #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
+		    #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Texture.hlsl"
+		    #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+		    #include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Lit/Lighting.hlsl"
+		    #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
+		    #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/TextureStack.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+		    #include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
+		    #include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
+
+			#if defined(LOD_FADE_CROSSFADE)
+				#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+			#endif
+
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/MotionVectorsCommon.hlsl"
+
+			/*ase_pragma*/
+
+			#if defined(ASE_EARLY_Z_DEPTH_OPTIMIZE) && (SHADER_TARGET >= 45)
+				#define ASE_SV_DEPTH SV_DepthLessEqual
+				#define ASE_SV_POSITION_QUALIFIERS linear noperspective centroid
+			#else
+				#define ASE_SV_DEPTH SV_Depth
+				#define ASE_SV_POSITION_QUALIFIERS
+			#endif
+
+			struct Attributes
+			{
+				float4 positionOS : POSITION;
+				float3 positionOld : TEXCOORD4;
+				#if _ADD_PRECOMPUTED_VELOCITY
+					float3 alembicMotionVector : TEXCOORD5;
+				#endif
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				/*ase_vdata:p=p;n=n;t=t;uv4=tc4;uv5=tc5*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct PackedVaryings
+			{
+				float4 positionCS : SV_POSITION;
+				float4 positionCSNoJitter : TEXCOORD0;
+				float4 previousPositionCSNoJitter : TEXCOORD1;
+				float3 positionWS : TEXCOORD2;
+				/*ase_interp(3,):sp=sp.xyzw*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+			#ifdef ASE_TRANSMISSION
+				float _TransmissionShadow;
+			#endif
+			#ifdef ASE_TRANSLUCENCY
+				float _TransStrength;
+				float _TransNormal;
+				float _TransScattering;
+				float _TransDirect;
+				float _TransAmbient;
+				float _TransShadow;
+			#endif
+			#ifdef ASE_TESSELLATION
+				float _TessPhongStrength;
+				float _TessValue;
+				float _TessMin;
+				float _TessMax;
+				float _TessEdgeLength;
+				float _TessMaxDisp;
+			#endif
+			CBUFFER_END
+
+			#ifdef SCENEPICKINGPASS
+				float4 _SelectionID;
+			#endif
+
+			#ifdef SCENESELECTIONPASS
+				int _ObjectId;
+				int _PassValue;
+			#endif
+
+			/*ase_globals*/
+
+			/*ase_funcs*/
+
+			PackedVaryings VertexFunction( Attributes input /*ase_vert_input*/ )
+			{
+				PackedVaryings output = (PackedVaryings)0;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+				/*ase_vert_code:input=Attributes;output=PackedVaryings*/
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					float3 defaultVertexValue = input.positionOS.xyz;
+				#else
+					float3 defaultVertexValue = float3(0, 0, 0);
+				#endif
+
+				float3 vertexValue = /*ase_vert_out:Vertex Offset;Float3;8;-1;_Vertex*/defaultVertexValue/*end*/;
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					input.positionOS.xyz = vertexValue;
+				#else
+					input.positionOS.xyz += vertexValue;
+				#endif
+
+				VertexPositionInputs vertexInput = GetVertexPositionInputs( input.positionOS.xyz );
+
+				#if defined(APPLICATION_SPACE_WARP_MOTION)
+					output.positionCSNoJitter = mul(_NonJitteredViewProjMatrix, mul(UNITY_MATRIX_M, input.positionOS));;
+					output.positionCS = output.positionCSNoJitter;
+				#else
+					output.positionCS = vertexInput.positionCS;
+					output.positionCSNoJitter = mul(_NonJitteredViewProjMatrix, mul(UNITY_MATRIX_M, input.positionOS));
+				#endif
+
+				float4 prevPos = ( unity_MotionVectorsParams.x == 1 ) ? float4( input.positionOld, 1 ) : input.positionOS;
+
+				#if _ADD_PRECOMPUTED_VELOCITY
+					prevPos = prevPos - float4(input.alembicMotionVector, 0);
+				#endif
+
+				output.previousPositionCSNoJitter = mul( _PrevViewProjMatrix, mul( UNITY_PREV_MATRIX_M, prevPos ) );
+
+				output.positionWS = vertexInput.positionWS;
+
+				// removed in ObjectMotionVectors.hlsl found in unity 6000.0.23 and higher
+				//ApplyMotionVectorZBias( output.positionCS );
+				return output;
+			}
+
+			PackedVaryings vert ( Attributes input )
+			{
+				return VertexFunction( input );
+			}
+
+			half4 frag(	PackedVaryings input
+				#if defined( ASE_DEPTH_WRITE_ON )
+				,out float outputDepth : ASE_SV_DEPTH
+				#endif
+				/*ase_frag_input*/ ) : SV_Target
+			{
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX( input );
+
+				/*ase_local_var:wp*/float3 PositionWS = input.positionWS;
+				/*ase_local_var:rwp*/float3 PositionRWS = GetCameraRelativePositionWS( PositionWS );
+				/*ase_local_var:spn*/float4 ScreenPosNorm = float4( GetNormalizedScreenSpaceUV( input.positionCS ), input.positionCS.zw );
+				/*ase_local_var:sp*/float4 ClipPos = ComputeClipSpacePosition( ScreenPosNorm.xy, input.positionCS.z ) * input.positionCS.w;
+
+				/*ase_frag_code:input=PackedVaryings*/
+
+				float Alpha = /*ase_frag_out:Alpha;Float;6;-1;_Alpha*/1/*end*/;
+				float AlphaClipThreshold = /*ase_frag_out:Alpha Clip Threshold;Float;7;-1;_AlphaClip*/0.5/*end*/;
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					float DeviceDepth = /*ase_frag_out:Depth;Float;17;-1;_DepthValue*/input.positionCS.z/*end*/;
+				#endif
+
+				#ifdef _ALPHATEST_ON
+					clip(Alpha - AlphaClipThreshold);
+				#endif
+
+				#if defined(ASE_CHANGES_WORLD_POS)
+					float3 positionOS = mul( GetWorldToObjectMatrix(),  float4( PositionWS, 1.0 ) ).xyz;
+					float3 previousPositionWS = mul( GetPrevObjectToWorldMatrix(),  float4( positionOS, 1.0 ) ).xyz;
+					input.positionCSNoJitter = mul( _NonJitteredViewProjMatrix, float4( PositionWS, 1.0 ) );
+					input.previousPositionCSNoJitter = mul( _PrevViewProjMatrix, float4( previousPositionWS, 1.0 ) );
+				#endif
+
+				#if defined(LOD_FADE_CROSSFADE)
+					LODFadeCrossFade( input.positionCS );
+				#endif
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					outputDepth = DeviceDepth;
+				#endif
+
+				#if defined(APPLICATION_SPACE_WARP_MOTION)
+					return float4( CalcAswNdcMotionVectorFromCsPositions( input.positionCSNoJitter, input.previousPositionCSNoJitter ), 1 );
+				#else
+					return float4( CalcNdcMotionVectorFromCsPositions( input.positionCSNoJitter, input.previousPositionCSNoJitter ), 0, 0 );
+				#endif
+			}
+			ENDHLSL
+		}
+
+		/*ase_pass*/
+		/*ase_hide_pass:SyncP*/
+		Pass
+		{
+			Name "WaterSSRData"
+            Tags
+            {
+                "LightMode" = "WaterSSRData"
+            }
+
+			ZWrite On
+            Cull[_Cull]
+            ZTest LEqual
+
+			Stencil
+            {
+                WriteMask 4
+                Ref 4
+                Comp Always
+                Pass Replace
+            }
+
+			HLSLPROGRAM
+
+			// Deferred Rendering Path does not support the OpenGL-based graphics API:
+			// Desktop OpenGL, OpenGL ES 3.0, WebGL 2.0.
+			#pragma exclude_renderers gles3 glcore
+
+			#pragma multi_compile_fragment _ _GBUFFER_NORMALS_OCT
+			#pragma shader_feature_local_fragment _ _WATER_REFLECTION_LEGACY
+
+			#pragma vertex vert
+			#pragma fragment frag
+
+			#if defined( _SPECULAR_SETUP ) && defined( ASE_LIGHTING_SIMPLE )
+				#if defined( _SPECULARHIGHLIGHTS_OFF )
+					#undef _SPECULAR_COLOR
+				#else
+					#define _SPECULAR_COLOR
+				#endif
+			#endif
+
+			#define SHADERPASS SHADERPASS_GBUFFER
+
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Color.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Texture.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Lit/Lighting.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Input.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/TextureStack.hlsl"
+            #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DBuffer.hlsl"
+			#include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
+
+			#if defined(LOD_FADE_CROSSFADE)
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+            #endif
+
+			#if defined( UNITY_INSTANCING_ENABLED ) && defined( ASE_INSTANCED_TERRAIN ) && ( defined(_TERRAIN_INSTANCED_PERPIXEL_NORMAL) || defined(_INSTANCEDTERRAINNORMALS_PIXEL) )
+				#define ENABLE_TERRAIN_PERPIXEL_NORMAL
+			#endif
+
+			/*ase_pragma*/
+
+			#if defined(ASE_EARLY_Z_DEPTH_OPTIMIZE) && (SHADER_TARGET >= 45)
+				#define ASE_SV_DEPTH SV_DepthLessEqual
+				#define ASE_SV_POSITION_QUALIFIERS linear noperspective centroid
+			#else
+				#define ASE_SV_DEPTH SV_Depth
+				#define ASE_SV_POSITION_QUALIFIERS
+			#endif
+
+			struct Attributes
+			{
+				float4 positionOS : POSITION;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				float4 texcoord : TEXCOORD0;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					float4 texcoord1 : TEXCOORD1;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					float4 texcoord2 : TEXCOORD2;
+				#endif
+				/*ase_vdata:p=p;n=n;t=t;uv0=tc0;uv1=tc1;uv2=tc2*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct PackedVaryings
+			{
+				ASE_SV_POSITION_QUALIFIERS float4 positionCS : SV_POSITION;
+				float3 positionWS : TEXCOORD0;
+				half3 normalWS : TEXCOORD1;
+				float4 tangentWS : TEXCOORD2; // holds terrainUV ifdef ENABLE_TERRAIN_PERPIXEL_NORMAL
+				float4 lightmapUVOrVertexSH : TEXCOORD3;
+				#if defined(ASE_FOG) || defined(_ADDITIONAL_LIGHTS_VERTEX)
+					half4 fogFactorAndVertexLight : TEXCOORD4;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON)
+					float2 dynamicLightmapUV : TEXCOORD5;
+				#endif
+				#if defined(USE_APV_PROBE_OCCLUSION)
+					float4 probeOcclusion : TEXCOORD6;
+				#endif
+				/*ase_interp(7,):sp=sp;wp=tc0.xyz;wn.xyz=tc1.xyz;wt.xyz=tc2.xyz*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+			#ifdef ASE_TRANSMISSION
+				float _TransmissionShadow;
+			#endif
+			#ifdef ASE_TRANSLUCENCY
+				float _TransStrength;
+				float _TransNormal;
+				float _TransScattering;
+				float _TransDirect;
+				float _TransAmbient;
+				float _TransShadow;
+			#endif
+			#ifdef ASE_TESSELLATION
+				float _TessPhongStrength;
+				float _TessValue;
+				float _TessMin;
+				float _TessMax;
+				float _TessEdgeLength;
+				float _TessMaxDisp;
+			#endif
+			CBUFFER_END
+
+			#ifdef SCENEPICKINGPASS
+				float4 _SelectionID;
+			#endif
+
+			#ifdef SCENESELECTIONPASS
+				int _ObjectId;
+				int _PassValue;
+			#endif
+
+			/*ase_globals*/
+
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/GBufferOutput.hlsl"
+
+			/*ase_funcs*/
+
+			PackedVaryings VertexFunction( Attributes input /*ase_vert_input*/ )
+			{
+				PackedVaryings output = (PackedVaryings)0;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+				/*ase_vert_code:input=Attributes;output=PackedVaryings*/
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					float3 defaultVertexValue = input.positionOS.xyz;
+				#else
+					float3 defaultVertexValue = float3(0, 0, 0);
+				#endif
+
+				float3 vertexValue = /*ase_vert_out:Vertex Offset;Float3;8;-1;_Vertex*/defaultVertexValue/*end*/;
+
+				#ifdef ASE_ABSOLUTE_VERTEX_POS
+					input.positionOS.xyz = vertexValue;
+				#else
+					input.positionOS.xyz += vertexValue;
+				#endif
+
+				input.normalOS = /*ase_vert_out:Vertex Normal;Float3;10;-1;_Normal*/input.normalOS/*end*/;
+				input.tangentOS = /*ase_vert_out:Vertex Tangent;Float4;30;-1;_Tangent*/input.tangentOS/*end*/;
+
+				VertexPositionInputs vertexInput = GetVertexPositionInputs( input.positionOS.xyz );
+				VertexNormalInputs normalInput = GetVertexNormalInputs( input.normalOS, input.tangentOS );
+
+				OUTPUT_LIGHTMAP_UV(input.texcoord1, unity_LightmapST, output.lightmapUVOrVertexSH.xy);
+				#if defined(DYNAMICLIGHTMAP_ON)
+					output.dynamicLightmapUV.xy = input.texcoord2.xy * unity_DynamicLightmapST.xy + unity_DynamicLightmapST.zw;
+				#endif
+				OUTPUT_SH4(vertexInput.positionWS, normalInput.normalWS.xyz, GetWorldSpaceNormalizeViewDir(vertexInput.positionWS), output.lightmapUVOrVertexSH.xyz, output.probeOcclusion);
+
+				#if defined(ASE_FOG) || defined(_ADDITIONAL_LIGHTS_VERTEX)
+					output.fogFactorAndVertexLight = 0;
+					#if defined(ASE_FOG) && !defined(_FOG_FRAGMENT)
+						// @diogo: no fog applied in GBuffer
+					#endif
+					#ifdef _ADDITIONAL_LIGHTS_VERTEX
+						half3 vertexLight = VertexLighting( vertexInput.positionWS, normalInput.normalWS );
+						output.fogFactorAndVertexLight.yzw = vertexLight;
+					#endif
+				#endif
+
+				output.positionCS = vertexInput.positionCS;
+				output.positionWS = vertexInput.positionWS;
+				output.normalWS = normalInput.normalWS;
+				output.tangentWS = float4( normalInput.tangentWS, ( input.tangentOS.w > 0.0 ? 1.0 : -1.0 ) * GetOddNegativeScale() );
+
+				#if defined( ENABLE_TERRAIN_PERPIXEL_NORMAL )
+					output.tangentWS.zw = input.texcoord.xy;
+					output.tangentWS.xy = input.texcoord.xy * unity_LightmapST.xy + unity_LightmapST.zw;
+				#endif
+				return output;
+			}
+
+			#if defined(ASE_TESSELLATION)
+			struct VertexControl
+			{
+				float4 positionOS : INTERNALTESSPOS;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				float4 texcoord : TEXCOORD0;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					float4 texcoord1 : TEXCOORD1;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					float4 texcoord2 : TEXCOORD2;
+				#endif
+				/*ase_vcontrol*/
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct TessellationFactors
+			{
+				float edge[3] : SV_TessFactor;
+				float inside : SV_InsideTessFactor;
+			};
+
+			VertexControl vert ( Attributes input )
+			{
+				VertexControl output;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				output.positionOS = input.positionOS;
+				output.normalOS = input.normalOS;
+				output.tangentOS = input.tangentOS;
+				output.texcoord = input.texcoord;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					output.texcoord1 = input.texcoord1;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					output.texcoord2 = input.texcoord2;
+				#endif
+				/*ase_control_code:input=Attributes;output=VertexControl*/
+				return output;
+			}
+
+			TessellationFactors TessellationFunction (InputPatch<VertexControl,3> input)
+			{
+				TessellationFactors output;
+				float4 tf = 1;
+				float tessValue = /*ase_inline_begin*/_TessValue/*ase_inline_end*/; float tessMin = /*ase_inline_begin*/_TessMin/*ase_inline_end*/; float tessMax = /*ase_inline_begin*/_TessMax/*ase_inline_end*/;
+				float edgeLength = /*ase_inline_begin*/_TessEdgeLength/*ase_inline_end*/; float tessMaxDisp = /*ase_inline_begin*/_TessMaxDisp/*ase_inline_end*/;
+				#if defined(ASE_FIXED_TESSELLATION)
+				tf = FixedTess( tessValue );
+				#elif defined(ASE_DISTANCE_TESSELLATION)
+				tf = DistanceBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, tessValue, tessMin, tessMax, GetObjectToWorldMatrix(), _WorldSpaceCameraPos );
+				#elif defined(ASE_LENGTH_TESSELLATION)
+				tf = EdgeLengthBasedTess(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams );
+				#elif defined(ASE_LENGTH_CULL_TESSELLATION)
+				tf = EdgeLengthBasedTessCull(input[0].positionOS, input[1].positionOS, input[2].positionOS, edgeLength, tessMaxDisp, GetObjectToWorldMatrix(), _WorldSpaceCameraPos, _ScreenParams, unity_CameraWorldClipPlanes );
+				#endif
+				output.edge[0] = tf.x; output.edge[1] = tf.y; output.edge[2] = tf.z; output.inside = tf.w;
+				return output;
+			}
+
+			[domain("tri")]
+			[partitioning("fractional_odd")]
+			[outputtopology("triangle_cw")]
+			[patchconstantfunc("TessellationFunction")]
+			[outputcontrolpoints(3)]
+			VertexControl HullFunction(InputPatch<VertexControl, 3> patch, uint id : SV_OutputControlPointID)
+			{
+				return patch[id];
+			}
+
+			[domain("tri")]
+			PackedVaryings DomainFunction(TessellationFactors factors, OutputPatch<VertexControl, 3> patch, float3 bary : SV_DomainLocation)
+			{
+				Attributes output = (Attributes) 0;
+				output.positionOS = patch[0].positionOS * bary.x + patch[1].positionOS * bary.y + patch[2].positionOS * bary.z;
+				output.normalOS = patch[0].normalOS * bary.x + patch[1].normalOS * bary.y + patch[2].normalOS * bary.z;
+				output.tangentOS = patch[0].tangentOS * bary.x + patch[1].tangentOS * bary.y + patch[2].tangentOS * bary.z;
+				output.texcoord = patch[0].texcoord * bary.x + patch[1].texcoord * bary.y + patch[2].texcoord * bary.z;
+				#if defined(LIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES1)
+					output.texcoord1 = patch[0].texcoord1 * bary.x + patch[1].texcoord1 * bary.y + patch[2].texcoord1 * bary.z;
+				#endif
+				#if defined(DYNAMICLIGHTMAP_ON) || defined(ASE_NEEDS_TEXTURE_COORDINATES2)
+					output.texcoord2 = patch[0].texcoord2 * bary.x + patch[1].texcoord2 * bary.y + patch[2].texcoord2 * bary.z;
+				#endif
+				/*ase_domain_code:patch=VertexControl;output=Attributes;bary=SV_DomainLocation*/
+				#if defined(ASE_PHONG_TESSELLATION)
+				float3 pp[3];
+				for (int i = 0; i < 3; ++i)
+					pp[i] = output.positionOS.xyz - patch[i].normalOS * (dot(output.positionOS.xyz, patch[i].normalOS) - dot(patch[i].positionOS.xyz, patch[i].normalOS));
+				float phongStrength = /*ase_inline_begin*/_TessPhongStrength/*ase_inline_end*/;
+				output.positionOS.xyz = phongStrength * (pp[0]*bary.x + pp[1]*bary.y + pp[2]*bary.z) + (1.0f-phongStrength) * output.positionOS.xyz;
+				#endif
+				UNITY_TRANSFER_INSTANCE_ID(patch[0], output);
+				return VertexFunction(output);
+			}
+			#else
+			PackedVaryings vert ( Attributes input )
+			{
+				return VertexFunction( input );
+			}
+			#endif
+
+			void frag ( PackedVaryings input
+								#if defined( ASE_DEPTH_WRITE_ON )
+								,out float outputDepth : ASE_SV_DEPTH
+								#endif
+								, out half4 outWaterSSRData : SV_Target0
+								/*ase_frag_input*/ )
+			{
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+				#if defined(_WATER_REFLECTION_LEGACY)
+					discard;
+				#endif
+
+				#if defined(LOD_FADE_CROSSFADE)
+					LODFadeCrossFade( input.positionCS );
+				#endif
+
+				#if defined(MAIN_LIGHT_CALCULATE_SHADOWS)
+					float4 shadowCoord = TransformWorldToShadowCoord( input.positionWS );
+				#else
+					float4 shadowCoord = float4(0, 0, 0, 0);
+				#endif
+
+				// @diogo: mikktspace compliant
+				float renormFactor = 1.0 / max( FLT_MIN, length( input.normalWS ) );
+
+				/*ase_local_var:wp*/float3 PositionWS = input.positionWS;
+				/*ase_local_var:rwp*/float3 PositionRWS = GetCameraRelativePositionWS( PositionWS );
+				/*ase_local_var:wvd*/float3 ViewDirWS = GetWorldSpaceNormalizeViewDir( PositionWS );
+				/*ase_local_var:sc*/float4 ShadowCoord = shadowCoord;
+				/*ase_local_var:spn*/float4 ScreenPosNorm = float4( GetNormalizedScreenSpaceUV( input.positionCS ), input.positionCS.zw );
+				/*ase_local_var:sp*/float4 ClipPos = ComputeClipSpacePosition( ScreenPosNorm.xy, input.positionCS.z ) * input.positionCS.w;
+				/*ase_local_var:spu*/float4 ScreenPos = ComputeScreenPos( ClipPos );
+				/*ase_local_var:wt*/float3 TangentWS = input.tangentWS.xyz * renormFactor;
+				/*ase_local_var:wbt*/float3 BitangentWS = cross( input.normalWS, input.tangentWS.xyz ) * input.tangentWS.w * renormFactor;
+				/*ase_local_var:wn*/float3 NormalWS = input.normalWS * renormFactor;
+
+				#if defined( ENABLE_TERRAIN_PERPIXEL_NORMAL )
+					float2 sampleCoords = (input.tangentWS.zw / _TerrainHeightmapRecipSize.zw + 0.5f) * _TerrainHeightmapRecipSize.xy;
+					NormalWS = TransformObjectToWorldNormal(normalize(SAMPLE_TEXTURE2D(_TerrainNormalmapTexture, sampler_TerrainNormalmapTexture, sampleCoords).rgb * 2 - 1));
+					TangentWS = -cross(GetObjectToWorldMatrix()._13_23_33, NormalWS);
+					BitangentWS = cross(NormalWS, -TangentWS);
+				#endif
+
+				/*ase_frag_code:input=PackedVaryings*/
+
+				float3 Normal = /*ase_frag_out:Normal;Float3;1;-1;_FragNormal*/float3(0, 0, 1)/*end*/;
+				float Smoothness = 1.0;
+				float Alpha = /*ase_frag_out:Alpha;Float;6;-1;_Alpha*/1/*end*/;
+				float AlphaClipThreshold = /*ase_frag_out:Alpha Clip Threshold;Float;7;-1;_AlphaClip*/0.5/*end*/;
+
+				#ifdef ASE_DEPTH_WRITE_ON
+					float DepthValue = /*ase_frag_out:Depth Value;Float;17;-1;_DepthValue*/input.positionCS.z/*end*/;
+				#endif
+
+				#if defined( _ALPHATEST_ON )
+					AlphaDiscard( Alpha, AlphaClipThreshold );
+				#endif
+
+				#if defined( ASE_DEPTH_WRITE_ON )
+					outputDepth = DepthValue;
+				#endif
+
+				#if defined(_NORMALMAP)
+					#if _NORMAL_DROPOFF_TS
+						float3 waterNormalWS = TransformTangentToWorld(Normal, half3x3(TangentWS, BitangentWS, NormalWS));
+					#elif _NORMAL_DROPOFF_OS
+						float3 waterNormalWS = TransformObjectToWorldNormal(Normal);
+					#elif _NORMAL_DROPOFF_WS
+						float3 waterNormalWS = Normal;
+					#endif
+				#else
+					float3 waterNormalWS = NormalWS;
+				#endif
+
+				outWaterSSRData = half4(NormalizeNormalPerPixel(waterNormalWS), saturate(Smoothness));
+			}
+
+			ENDHLSL
+		}
+		/*ase_pass_end*/
+	}
+	/*ase_lod*/
+//	FallBack "Hidden/Shader Graph/FallbackError"
+	CustomEditor "AmplifyShaderEditor.MaterialInspector"
+}

--- a/Shaders/Water/Water Template.shader
+++ b/Shaders/Water/Water Template.shader
@@ -26,7 +26,7 @@ Shader /*ase_name*/ "Hidden/Universal/Water" /*end*/
 		[ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
 		[WaterReflectionMode] _WaterReflectionMode("Water Reflection Mode", Float) = 0
 
-        // WaterSSRData
+        // Depth passes
         [HideInInspector] _StencilRefDepth("_StencilRefDepth", Int) = 4 // IllusionStencilUsage.TraceReflectionRay
 		[HideInInspector] _StencilWriteMaskDepth("_StencilWriteMaskDepth", Int) = 5 // IllusionStencilUsage.ForwardGBufferWriteMask
 
@@ -646,6 +646,7 @@ Shader /*ase_name*/ "Hidden/Universal/Water" /*end*/
 			#endif
 
 			#define SHADERPASS SHADERPASS_FORWARD
+			#define ILLUSION_WATER_FORWARD_PASS 1
 
 			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
 			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
@@ -3042,14 +3043,6 @@ Shader /*ase_name*/ "Hidden/Universal/Water" /*end*/
 			ZWrite On
             Cull[_Cull]
             ZTest LEqual
-
-			Stencil
-            {
-                WriteMask 4
-                Ref 4
-                Comp Always
-                Pass Replace
-            }
 
 			HLSLPROGRAM
 

--- a/Shaders/Water/Water Template.shader.meta
+++ b/Shaders/Water/Water Template.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d7b9740d651f4f47a45c1ff0e4fac727
+timeCreated: 1785931200
+licenseType: Pro
+ShaderImporter:
+  defaultTextures: []
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Shaders/Water/Water.hlsl
+++ b/Shaders/Water/Water.hlsl
@@ -1,9 +1,15 @@
-﻿#ifndef WATER_LIGHTING_INCLUDED
+#ifndef WATER_LIGHTING_INCLUDED
 #define WATER_LIGHTING_INCLUDED
 
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DeclareDepthTexture.hlsl"
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
-#include "Packages/com.kurisu.illusion-render-pipelines/ShaderLibrary/DeclareMotionVectorTexture.hlsl"
+
+TEXTURE2D_X(_PreRefractionColorTexture);
+
+#if defined(_WATER_REFLECTION_LEGACY)
+    #include "Packages/com.kurisu.illusion-render-pipelines/ShaderLibrary/DeclareMotionVectorTexture.hlsl"
+    TEXTURE2D_X(_HistoryColorTexture);
+#endif
 
 #ifdef _SHADOW_SAMPLES_LOW
     #define SHADOW_ITERATIONS 1
@@ -29,7 +35,57 @@
     #define SSR_ITERATIONS 4
 #endif
 
-TEXTURE2D_X(_HistoryColorTexture);
+float2 WaterScreenTextureUV(float2 normalizedScreenSpaceUV)
+{
+    return UnityStereoTransformScreenSpaceTex(normalizedScreenSpaceUV) * _RTHandleScale.xy;
+}
+
+half3 SamplePreRefractionColor(float2 normalizedScreenSpaceUV)
+{
+    bool inBounds = all(normalizedScreenSpaceUV >= 0.0) && all(normalizedScreenSpaceUV <= 1.0);
+    if (!inBounds)
+        return 0.0;
+
+    half4 sceneColor = SAMPLE_TEXTURE2D_X_LOD(
+        _PreRefractionColorTexture, sampler_LinearClamp,
+        WaterScreenTextureUV(normalizedScreenSpaceUV), 0);
+    return all(isfinite(sceneColor)) ? sceneColor.rgb : 0.0;
+}
+
+half3 SamplePreRefractionColorDistorted(
+    float2 currentUV,
+    float2 distortedUV,
+    float surfaceEyeDepth)
+{
+    bool distortedInBounds = all(distortedUV >= 0.0) && all(distortedUV <= 1.0);
+    if (!distortedInBounds)
+        return SamplePreRefractionColor(currentUV);
+
+    float refractedEyeDepth = LinearEyeDepth(SampleSceneDepth(distortedUV), _ZBufferParams);
+    float2 safeUV = refractedEyeDepth <= surfaceEyeDepth ? currentUV : distortedUV;
+    return SamplePreRefractionColor(safeUV);
+}
+
+half4 SampleTransparentScreenSpaceReflection(float2 normalizedScreenSpaceUV)
+{
+    bool inBounds = all(normalizedScreenSpaceUV >= 0.0) && all(normalizedScreenSpaceUV <= 1.0);
+    if (!inBounds)
+        return 0.0;
+
+    half4 reflection = SAMPLE_TEXTURE2D_X_LOD(
+        _SsrLightingTexture, sampler_LinearClamp,
+        WaterScreenTextureUV(normalizedScreenSpaceUV), 0);
+    if (!all(isfinite(reflection)))
+        return 0.0;
+
+    reflection.a = saturate(reflection.a);
+    reflection.rgb *= GetInverseCurrentExposureMultiplier();
+
+    // The pipeline stores SSR lighting premultiplied by confidence, while the
+    // existing Water graph expects a straight color and applies confidence in its lerp.
+    reflection.rgb = reflection.a > 1e-4h ? reflection.rgb / reflection.a : 0.0h;
+    return reflection;
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 //                           Reflection Modes                                //
@@ -60,55 +116,50 @@ half OutOfBoundsFade(half2 uv)
     return fade.x * fade.y;
 }
 
-// Sample reflection from base pass raymarching
+// Compatibility entry point used by the existing ASE graph. Transparent SSR
+// tracing is owned by IllusionRP; this function only resolves the current
+// water pixel and forwards the pipeline confidence to the graph.
 void Raymarch_half(float3 origin, float3 direction, half steps, half stepSize, half thickness, out half2 sampleUV, out half valid, out half outOfBounds, out half debug)
 {
+#if defined(_WATER_REFLECTION_LEGACY)
     sampleUV = 0;
     valid = 0;
     outOfBounds = 0;
     debug = 0;
 
-    float3 baseOrigin = origin;
-    
     direction *= stepSize;
-    const half rcpStepCount = rcp(steps);
-    
+
     [loop]
-    for(int i = 0; i < steps; i++)
+    for (int i = 0; i < steps; i++)
     {
         debug++;
-        //if(valid == 0)
+        origin += direction;
+        direction *= 1.5;
+        sampleUV = ViewSpacePosToUV(origin);
+        outOfBounds = OutOfBoundsFade(sampleUV);
+
+        if (sampleUV.x > 1 || sampleUV.x < 0 || sampleUV.y > 1 || sampleUV.y < 0)
+            return;
+
+        float deviceDepth = SampleSceneDepth(sampleUV);
+        float3 samplePos = ViewPosFromDepth(sampleUV, deviceDepth);
+
+        if (distance(samplePos.z, origin.z) > length(direction) * thickness)
+            continue;
+
+        if (samplePos.z > origin.z)
         {
-            origin += direction;
-            direction *= 1.5;
-            sampleUV = ViewSpacePosToUV(origin);
-
-            outOfBounds = OutOfBoundsFade(sampleUV);
-            
-            //return;
-            
-            if(!(sampleUV.x > 1 || sampleUV.x < 0 || sampleUV.y > 1 || sampleUV.y < 0))
-            {
-                float deviceDepth = SampleSceneDepth(sampleUV);
-                float3 samplePos = ViewPosFromDepth(sampleUV, deviceDepth);
-
-                if(distance(samplePos.z, origin.z) > length(direction) * thickness) continue;
-
-                
-        
-                if(samplePos.z > origin.z)
-                {
-                    valid = 1;
-                    return;
-                }
-                
-            } else
-            {
-                //outOfBounds = OutOfBoundsFade(sampleUV);
-                return;
-            }
+            valid = 1;
+            return;
         }
     }
+#else
+    sampleUV = ViewSpacePosToUV(origin);
+    half4 reflection = SampleTransparentScreenSpaceReflection(sampleUV);
+    valid = reflection.a;
+    outOfBounds = 1.0;
+    debug = 0;
+#endif
 }
 
 struct WaveParams
@@ -185,44 +236,24 @@ void RadialGerstnerWaves_half(float3 worldPos, half time, out half displacement)
     //displacement /= summedAmplitude;
 }
 
-/*
-half3 SampleReflections(float3 normalWS, float3 positionWS, float3 viewDirectionWS, half2 screenUV)
-{
-    half3 reflection = 0;
-    half2 refOffset = 0;
-    
-    float2 uv = float2(0, 0);
-    half valid = 1;
-
-    float3 positionVS = TransformWorldToView(positionWS);
-    float3 normalVS = TransformWorldToViewDir(normalWS);
-
-    float3 positionVSnorm = normalize(positionVS);
-    float3 pivot = reflect(positionVS, normalVS);
-    half debug;
-    RayMarch(positionVS, pivot, uv, valid, debug);
-    half3 ssr = SAMPLE_TEXTURE2D(_CameraOpaqueTexture, sampler_ScreenTextures_linear_clamp, uv).rgb;
-
-    half3 backup = CubemapReflection(viewDirectionWS, positionWS, normalWS);
-    reflection = lerp(backup, ssr, valid);
-    //do backup
-    return reflection;
-}
-*/
-
 half4 SampleSceneColor_half(half2 screenUV)
 {
+#if defined(_WATER_REFLECTION_LEGACY)
     float2 forwardMotionVector;
-    DecodeMotionVector(SAMPLE_TEXTURE2D_X_LOD(_MotionVectorTexture, sampler_LinearClamp, screenUV, 0), forwardMotionVector);
-    float2 prevFrameUV = screenUV - forwardMotionVector; // backward
-    float2 limit = float2(1, 1);
-    if (any(prevFrameUV < float2(0.0,0.0)) || any(prevFrameUV > limit))
-    {
-        // Off-Screen.
-        return 0;
-    }
-    half4 preFrameColor = half4(SAMPLE_TEXTURE2D_X_LOD(_HistoryColorTexture, sampler_PointClamp, prevFrameUV, 0));
-    return half4(preFrameColor.rgb, 1.0);
+    DecodeMotionVector(
+        SAMPLE_TEXTURE2D_X_LOD(_MotionVectorTexture, sampler_LinearClamp, screenUV, 0),
+        forwardMotionVector);
+
+    float2 prevFrameUV = screenUV - forwardMotionVector;
+    if (any(prevFrameUV < 0.0) || any(prevFrameUV > 1.0))
+        return 0.0;
+
+    half3 previousColor = SAMPLE_TEXTURE2D_X_LOD(
+        _HistoryColorTexture, sampler_PointClamp, prevFrameUV, 0).rgb;
+    return half4(previousColor, 1.0);
+#else
+    return SampleTransparentScreenSpaceReflection(screenUV);
+#endif
 }
 
 

--- a/Shaders/Water/Water.hlsl
+++ b/Shaders/Water/Water.hlsl
@@ -5,6 +5,7 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
 
 TEXTURE2D_X(_PreRefractionColorTexture);
+TEXTURE2D_X_FLOAT(_WaterPreDepthTexture);
 
 #if defined(_WATER_REFLECTION_LEGACY)
     #include "Packages/com.kurisu.illusion-render-pipelines/ShaderLibrary/DeclareMotionVectorTexture.hlsl"
@@ -40,6 +41,17 @@ float2 WaterScreenTextureUV(float2 normalizedScreenSpaceUV)
     return UnityStereoTransformScreenSpaceTex(normalizedScreenSpaceUV) * _RTHandleScale.xy;
 }
 
+float SampleWaterSceneDepth(float2 normalizedScreenSpaceUV)
+{
+#if defined(_WATER_REFLECTION_LEGACY)
+    return SampleSceneDepth(normalizedScreenSpaceUV);
+#else
+    return SAMPLE_TEXTURE2D_X_LOD(
+        _WaterPreDepthTexture, sampler_PointClamp,
+        WaterScreenTextureUV(normalizedScreenSpaceUV), 0).r;
+#endif
+}
+
 half3 SamplePreRefractionColor(float2 normalizedScreenSpaceUV)
 {
     bool inBounds = all(normalizedScreenSpaceUV >= 0.0) && all(normalizedScreenSpaceUV <= 1.0);
@@ -61,7 +73,8 @@ half3 SamplePreRefractionColorDistorted(
     if (!distortedInBounds)
         return SamplePreRefractionColor(currentUV);
 
-    float refractedEyeDepth = LinearEyeDepth(SampleSceneDepth(distortedUV), _ZBufferParams);
+    float refractedDeviceDepth = SampleWaterSceneDepth(distortedUV);
+    float refractedEyeDepth = LinearEyeDepth(refractedDeviceDepth, _ZBufferParams);
     float2 safeUV = refractedEyeDepth <= surfaceEyeDepth ? currentUV : distortedUV;
     return SamplePreRefractionColor(safeUV);
 }

--- a/Shaders/Water/Water.shader
+++ b/Shaders/Water/Water.shader
@@ -46,9 +46,9 @@ Shader "Universal Render Pipeline/Water"
 		//[ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
 		[WaterReflectionMode] _WaterReflectionMode("Water Reflection Mode", Float) = 0
         
-        // WaterSSRData
+        // Depth passes
         [HideInInspector] _StencilRefDepth("_StencilRefDepth", Int) = 4 // IllusionStencilUsage.TraceReflectionRay
-        [HideInInspector] _StencilWriteMaskDepth("_StencilWriteMaskDepth", Int) = 5 // IllusionStencilUsage.WaterSSRDataWriteMask
+        [HideInInspector] _StencilWriteMaskDepth("_StencilWriteMaskDepth", Int) = 5 // IllusionStencilUsage.ForwardGBufferWriteMask
 		
 		[HideInInspector] _QueueOffset("_QueueOffset", Float) = 0
         [HideInInspector] _QueueControl("_QueueControl", Float) = -1
@@ -275,6 +275,7 @@ Shader "Universal Render Pipeline/Water"
 			#endif
 
 			#define SHADERPASS SHADERPASS_FORWARD
+			#define ILLUSION_WATER_FORWARD_PASS 1
 
 			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
 			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
@@ -959,17 +960,6 @@ Shader "Universal Render Pipeline/Water"
 			ZTest LEqual
 			Blend One Zero
 			ColorMask RGBA
-
-			Stencil
-			{
-				Ref 4
-				ReadMask 4
-				WriteMask 4
-				Comp Always
-				Pass Replace
-				Fail Keep
-				ZFail Keep
-			}
 
 			HLSLPROGRAM
 			#pragma target 3.5

--- a/Shaders/Water/Water.shader
+++ b/Shaders/Water/Water.shader
@@ -44,10 +44,11 @@ Shader "Universal Render Pipeline/Water"
 		[ToggleOff(_SPECULARHIGHLIGHTS_OFF)] _SpecularHighlights("Specular Highlights", Float) = 1.0
 		[ToggleOff] _EnvironmentReflections("Environment Reflections", Float) = 1.0
 		//[ToggleUI] _ReceiveShadows("Receive Shadows", Float) = 1.0
+		[WaterReflectionMode] _WaterReflectionMode("Water Reflection Mode", Float) = 0
         
-        // ForwardGBuffer
+        // WaterSSRData
         [HideInInspector] _StencilRefDepth("_StencilRefDepth", Int) = 4 // IllusionStencilUsage.TraceReflectionRay
-        [HideInInspector] _StencilWriteMaskDepth("_StencilWriteMaskDepth", Int) = 5 // IllusionStencilUsage.ForwardGBufferWriteMask
+        [HideInInspector] _StencilWriteMaskDepth("_StencilWriteMaskDepth", Int) = 5 // IllusionStencilUsage.WaterSSRDataWriteMask
 		
 		[HideInInspector] _QueueOffset("_QueueOffset", Float) = 0
         [HideInInspector] _QueueControl("_QueueControl", Float) = -1
@@ -246,11 +247,11 @@ Shader "Universal Render Pipeline/Water"
 			#pragma multi_compile _ _CLUSTER_LIGHT_LOOP
 			
 			// @IllusionRP Start
-			#pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
 			#pragma multi_compile_fragment _ _PRT_GLOBAL_ILLUMINATION
 			#pragma multi_compile_fragment _ _SCREEN_SPACE_REFLECTION
 			#pragma multi_compile_fragment _ _SCREEN_SPACE_GLOBAL_ILLUMINATION
 			#pragma multi_compile_fragment _ _SHADOW_BIAS_FRAGMENT
+			#pragma shader_feature_local_fragment _ _WATER_REFLECTION_LEGACY
 			// @IllusionRP End
 
 			#pragma multi_compile _ LIGHTMAP_SHADOW_MIXING
@@ -289,7 +290,7 @@ Shader "Universal Render Pipeline/Water"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
 			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
 			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Shadows.hlsl"
-			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl"
+			#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
 			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DBuffer.hlsl"
 			#include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
 
@@ -925,6 +926,11 @@ Shader "Universal Render Pipeline/Water"
 					#endif
 				#endif
 
+				#ifdef _SURFACE_TYPE_TRANSPARENT
+					color.rgb = lerp(SamplePreRefractionColor(ScreenPosNorm.xy), color.rgb, saturate(color.a));
+					color.a = 1.0;
+				#endif
+
 				#if defined( ASE_DEPTH_WRITE_ON )
 					outputDepth = DeviceDepth;
 				#endif
@@ -943,6 +949,148 @@ Shader "Universal Render Pipeline/Water"
 		}
 
 		
+		Pass
+		{
+			Name "WaterSSRData"
+			Tags { "LightMode" = "WaterSSRData" }
+
+			Cull Back
+			ZWrite On
+			ZTest LEqual
+			Blend One Zero
+			ColorMask RGBA
+
+			Stencil
+			{
+				Ref 4
+				ReadMask 4
+				WriteMask 4
+				Comp Always
+				Pass Replace
+				Fail Keep
+				ZFail Keep
+			}
+
+			HLSLPROGRAM
+			#pragma target 3.5
+			#pragma exclude_renderers gles3 glcore
+			#pragma vertex WaterSSRDataVertex
+			#pragma fragment WaterSSRDataFragment
+			#pragma shader_feature_local_fragment _ _WATER_REFLECTION_LEGACY
+			#pragma multi_compile_instancing
+			#pragma instancing_options renderinglayer
+			#pragma multi_compile _ LOD_FADE_CROSSFADE
+			#include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+			#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Packing.hlsl"
+
+			#if defined(LOD_FADE_CROSSFADE)
+			#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+			#endif
+
+			struct WaterSSRDataAttributes
+			{
+				float4 positionOS : POSITION;
+				half3 normalOS : NORMAL;
+				half4 tangentOS : TANGENT;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+			};
+
+			struct WaterSSRDataVaryings
+			{
+				float4 positionCS : SV_POSITION;
+				float3 positionWS : TEXCOORD0;
+				half3 normalWS : TEXCOORD1;
+				half4 tangentWS : TEXCOORD2;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
+			};
+
+			CBUFFER_START(UnityPerMaterial)
+				float4 _ColorBright;
+				float4 _ColorDeep;
+				float4 _EdgeColor;
+				float2 _BlendOffsetSpeed;
+				float2 _RefractionFade;
+				float2 _WaterDepthRange;
+				float _NormalTiling1;
+				float _OffsetSpeed;
+				float _NormalTiling2;
+				float _BlendTiling;
+				float _NormalMapStrength;
+				float _Metallic;
+				float _EdgeFade;
+				float _RefractIntensity;
+				float _ColorAlpha;
+			CBUFFER_END
+
+			TEXTURE2D(_Normal_Map);
+			SAMPLER(sampler_Normal_Map);
+			TEXTURE2D(_Blend_Map);
+			SAMPLER(sampler_Blend_Map);
+
+			WaterSSRDataVaryings WaterSSRDataVertex(WaterSSRDataAttributes input)
+			{
+				WaterSSRDataVaryings output = (WaterSSRDataVaryings)0;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, output);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+				VertexPositionInputs positionInputs = GetVertexPositionInputs(input.positionOS.xyz);
+				VertexNormalInputs normalInputs = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+				output.positionCS = positionInputs.positionCS;
+				output.positionWS = positionInputs.positionWS;
+				output.normalWS = normalInputs.normalWS;
+				output.tangentWS = half4(
+					normalInputs.tangentWS,
+					(input.tangentOS.w > 0.0 ? 1.0 : -1.0) * GetOddNegativeScale());
+				return output;
+			}
+
+			half4 WaterSSRDataFragment(WaterSSRDataVaryings input) : SV_Target
+			{
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+				#if defined(_WATER_REFLECTION_LEGACY)
+					discard;
+				#endif
+
+				#if defined(LOD_FADE_CROSSFADE)
+				LODFadeCrossFade(input.positionCS);
+				#endif
+
+				float2 positionXZ = input.positionWS.xz;
+				float normalOffset = _OffsetSpeed * _TimeParameters.x;
+				float2 normalUV1 = positionXZ * _NormalTiling1 + float2(normalOffset * -0.5, 0.0);
+				float2 normalUV2 = positionXZ * _NormalTiling2 + float2(normalOffset, 0.0);
+				float2 blendUV = positionXZ * (_BlendTiling * 2.0) + _TimeParameters.y * _BlendOffsetSpeed;
+
+				half3 normalTS = normalize(lerp(
+					UnpackNormalScale(SAMPLE_TEXTURE2D(_Normal_Map, sampler_Normal_Map, normalUV1), 1.0),
+					UnpackNormalScale(SAMPLE_TEXTURE2D(_Normal_Map, sampler_Normal_Map, normalUV2), 1.0),
+					SAMPLE_TEXTURE2D(_Blend_Map, sampler_Blend_Map, blendUV).r));
+				normalTS = half3(
+					normalTS.xy * _NormalMapStrength,
+					lerp(1.0, normalTS.z, saturate(_NormalMapStrength)));
+
+				float renormFactor = rcp(max(FLT_MIN, length(input.normalWS)));
+				float3 normalWS = input.normalWS * renormFactor;
+				float3 tangentWS = input.tangentWS.xyz * renormFactor;
+				float3 bitangentWS = cross(input.normalWS, input.tangentWS.xyz)
+					* input.tangentWS.w * renormFactor;
+				float3x3 tangentToWorld = float3x3(
+					tangentWS.x, bitangentWS.x, normalWS.x,
+					tangentWS.y, bitangentWS.y, normalWS.y,
+					tangentWS.z, bitangentWS.z, normalWS.z);
+				float3 reflectionNormalWS = normalize(mul(tangentToWorld, normalTS));
+
+				return half4(reflectionNormalWS, 1.0);
+			}
+			ENDHLSL
+		}
+
 		Pass
 		{
 			
@@ -991,7 +1139,7 @@ Shader "Universal Render Pipeline/Water"
             #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRendering.hlsl"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/DebugMipmapStreamingMacros.hlsl"
-		    #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl"
+		    #include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/WaterShaderGraphFunctions.hlsl"
 		    #include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/ShaderPass.hlsl"
 
 			#if defined(LOD_FADE_CROSSFADE)
@@ -1334,14 +1482,14 @@ Node;AmplifyShaderEditor.ReflectionProbeNode, AmplifyShaderEditor, Version=0.0.0
 Node;AmplifyShaderEditor.CustomExpressionNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;254;-1274.309,-554.4213;Half;False;$float2 ViewSpacePosToUV(float3 pos)${$    return ComputeNormalizedDeviceCoordinates(pos, UNITY_MATRIX_P)@$}$$half OutOfBoundsFade(half2 uv)${$    half2 fade = 0@$    fade.x = saturate(1 - abs(uv.x - 0.5) * 2)@$    fade.y = saturate(1 - abs(uv.y - 0.5) * 2)@$    return fade.x * fade.y@$}$ $sampleUV = 0@$    valid = 0@$    outOfBounds = 0@$    debug = 0@$$    float3 baseOrigin = origin@$    $    direction *= stepSize@$    const half rcpStepCount = rcp(steps)@$    $    [loop]$    for(int i = 0@ i < steps@ i++)$    {$        debug++@$        //if(valid == 0)$        {$            origin += direction@$            direction *= 1.5@$            sampleUV = ViewSpacePosToUV(origin)@$$            outOfBounds = OutOfBoundsFade(sampleUV)@$            $            //return@$            $            if(!(sampleUV.x > 1 || sampleUV.x < 0 || sampleUV.y > 1 || sampleUV.y < 0))$            {$                float deviceDepth = SampleSceneDepth(sampleUV)@$                float3 samplePos = ViewPosFromDepth(sampleUV, deviceDepth)@$$                if(distance(samplePos.z, origin.z) > length(direction) * thickness) continue@$$                $        $                if(samplePos.z > origin.z)$                {$                    valid = 1@$                    return@$                }$                $            } else$            {$                //outOfBounds = OutOfBoundsFade(sampleUV)@$                return@$            }$        }$    };4;File;1;False;screenUV;FLOAT2;0,0;In;;Inherit;False;SampleSceneColor;False;False;0;b70f2f9c654fd44dca3ff648d097683e;True;1;0;FLOAT2;0,0;False;1;FLOAT4;0
 Node;AmplifyShaderEditor.CustomExpressionNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;49;-1455.999,-1513.674;Half;False;$float2 ViewSpacePosToUV(float3 pos)${$    return ComputeNormalizedDeviceCoordinates(pos, UNITY_MATRIX_P)@$}$$half OutOfBoundsFade(half2 uv)${$    half2 fade = 0@$    fade.x = saturate(1 - abs(uv.x - 0.5) * 2)@$    fade.y = saturate(1 - abs(uv.y - 0.5) * 2)@$    return fade.x * fade.y@$}$ $sampleUV = 0@$    valid = 0@$    outOfBounds = 0@$    debug = 0@$$    float3 baseOrigin = origin@$    $    direction *= stepSize@$    const half rcpStepCount = rcp(steps)@$    $    [loop]$    for(int i = 0@ i < steps@ i++)$    {$        debug++@$        //if(valid == 0)$        {$            origin += direction@$            direction *= 1.5@$            sampleUV = ViewSpacePosToUV(origin)@$$            outOfBounds = OutOfBoundsFade(sampleUV)@$            $            //return@$            $            if(!(sampleUV.x > 1 || sampleUV.x < 0 || sampleUV.y > 1 || sampleUV.y < 0))$            {$                float deviceDepth = SampleSceneDepth(sampleUV)@$                float3 samplePos = ViewPosFromDepth(sampleUV, deviceDepth)@$$                if(distance(samplePos.z, origin.z) > length(direction) * thickness) continue@$$                $        $                if(samplePos.z > origin.z)$                {$                    valid = 1@$                    return@$                }$                $            } else$            {$                //outOfBounds = OutOfBoundsFade(sampleUV)@$                return@$            }$        }$    };8;File;9;True;origin;FLOAT3;0,0,0;In;;Inherit;False;True;direction;FLOAT3;0,0,0;In;;Inherit;False;True;steps;FLOAT;12;In;;Inherit;False;True;stepSize;FLOAT;0.2;In;;Inherit;False;True;thickness;FLOAT;1;In;;Inherit;False;True;sampleUV;FLOAT2;0,0;Out;;Inherit;False;True;valid;FLOAT;0;Out;;Inherit;False;True;outOfBounds;FLOAT;0;Out;;Inherit;False;True;debug;FLOAT;0;Out;;Inherit;False;Raymarch;False;False;0;b70f2f9c654fd44dca3ff648d097683e;True;10;0;FLOAT;0;False;1;FLOAT3;0,0,0;False;2;FLOAT3;0,0,0;False;3;FLOAT;12;False;4;FLOAT;0.2;False;5;FLOAT;1;False;6;FLOAT2;0,0;False;7;FLOAT;0;False;8;FLOAT;0;False;9;FLOAT;0;False;5;FLOAT;0;FLOAT2;7;FLOAT;8;FLOAT;9;FLOAT;10
 Node;AmplifyShaderEditor.CustomExpressionNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;253;-1170.115,-1676.302;Half;False;$float2 ViewSpacePosToUV(float3 pos)${$    return ComputeNormalizedDeviceCoordinates(pos, UNITY_MATRIX_P)@$}$$half OutOfBoundsFade(half2 uv)${$    half2 fade = 0@$    fade.x = saturate(1 - abs(uv.x - 0.5) * 2)@$    fade.y = saturate(1 - abs(uv.y - 0.5) * 2)@$    return fade.x * fade.y@$}$ $sampleUV = 0@$    valid = 0@$    outOfBounds = 0@$    debug = 0@$$    float3 baseOrigin = origin@$    $    direction *= stepSize@$    const half rcpStepCount = rcp(steps)@$    $    [loop]$    for(int i = 0@ i < steps@ i++)$    {$        debug++@$        //if(valid == 0)$        {$            origin += direction@$            direction *= 1.5@$            sampleUV = ViewSpacePosToUV(origin)@$$            outOfBounds = OutOfBoundsFade(sampleUV)@$            $            //return@$            $            if(!(sampleUV.x > 1 || sampleUV.x < 0 || sampleUV.y > 1 || sampleUV.y < 0))$            {$                float deviceDepth = SampleSceneDepth(sampleUV)@$                float3 samplePos = ViewPosFromDepth(sampleUV, deviceDepth)@$$                if(distance(samplePos.z, origin.z) > length(direction) * thickness) continue@$$                $        $                if(samplePos.z > origin.z)$                {$                    valid = 1@$                    return@$                }$                $            } else$            {$                //outOfBounds = OutOfBoundsFade(sampleUV)@$                return@$            }$        }$    };4;File;1;False;screenUV;FLOAT2;0,0;In;;Inherit;False;SampleSceneColor;False;False;0;b70f2f9c654fd44dca3ff648d097683e;True;1;0;FLOAT2;0,0;False;1;FLOAT4;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;2;0,0;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;1;New Amplify Shader;368b90cdf7a92c5479634d4a85261b5e;True;ShadowCaster;0;1;ShadowCaster;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;False;False;True;False;False;False;False;0;False;;False;False;False;False;False;False;False;False;False;True;1;False;;True;3;False;;False;True;1;LightMode=ShadowCaster;False;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;3;0,0;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;1;New Amplify Shader;368b90cdf7a92c5479634d4a85261b5e;True;DepthOnly;0;2;DepthOnly;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;False;False;True;False;False;False;False;0;False;;False;False;False;False;False;False;False;True;True;0;True;_StencilRefDepth;255;False;;255;True;_StencilWriteMaskDepth;7;False;;3;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;False;False;True;1;LightMode=DepthOnly;False;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;4;0,0;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;1;New Amplify Shader;368b90cdf7a92c5479634d4a85261b5e;True;Meta;0;3;Meta;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Meta;False;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;6;0,0;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;1;New Amplify Shader;368b90cdf7a92c5479634d4a85261b5e;True;GBuffer;0;4;GBuffer;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;True;1;5;False;;10;False;;1;1;False;;10;False;;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;True;True;True;True;0;False;;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;1;LightMode=UniversalGBuffer;False;True;12;d3d11;gles;metal;vulkan;xboxone;xboxseries;playstation;ps4;ps5;switch;switch2;webgpu;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;1;1897.124,-2275.099;Float;False;True;-1;2;AmplifyShaderEditor.MaterialInspector;0;21;Universal Render Pipeline/Water;368b90cdf7a92c5479634d4a85261b5e;True;Forward;0;0;Forward;21;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;2;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Transparent=RenderType;Queue=Transparent=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;True;1;5;False;;10;False;;1;1;False;;10;False;;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;True;True;True;True;0;False;;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;1;LightMode=UniversalForwardOnly;False;False;0;;0;0;Standard;50;Category;0;0;  Instanced Terrain Normals;1;0;Lighting Model;0;0;Workflow;1;0;Surface;1;638812485755269428;  Keep Alpha;0;0;  Refraction Model;0;0;  Blend;0;0;Two Sided;1;0;Alpha Clipping;1;0;  Use Shadow Threshold;0;0;Fragment Normal Space;0;0;Forward Only;1;638812485901019111;Transmission;0;0;  Transmission Shadow;0.5,False,;0;Translucency;0;0;  Translucency Strength;1,False,;0;  Normal Distortion;0.5,False,;0;  Scattering;2,False,;0;  Direct;0.9,False,;0;  Ambient;0.1,False,;0;  Shadow;0.5,False,;0;Cast Shadows;0;638812594748085911;Receive Shadows;1;0;Specular Highlights;2;0;Environment Reflections;2;0;Receive SSAO;1;0;Motion Vectors;1;0;  Add Precomputed Velocity;0;0;  XR Motion Vectors;0;0;GPU Instancing;1;0;LOD CrossFade;1;0;Built-in Fog;1;0;_FinalColorxAlpha;0;0;Meta Pass;0;638812485795591478;Override Baked GI;0;0;Tessellation;0;0;  Phong;0;0;  Strength;0.5,False,;0;  Type;0;0;  Tess;16,False,;0;  Min;10,False,;0;  Max;25,False,;0;  Edge Length;16,False,;0;  Max Displacement;25,False,;0;Write Depth;0;0;  Early Z;0;0;Vertex Position;1;0;Debug Display;0;0;Clear Coat;0;0;0;8;True;False;False;False;False;True;False;False;False;;True;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;252;1897.124,-1971.649;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;21;New Amplify Shader;368b90cdf7a92c5479634d4a85261b5e;True;ForwardGBuffer;0;7;ForwardGBuffer;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;2;False;;True;5;False;;False;True;1;LightMode=ForwardGBuffer;False;True;12;d3d11;gles;metal;vulkan;xboxone;xboxseries;playstation;ps4;ps5;switch;switch2;webgpu;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;255;1897.124,-2215.099;Float;False;False;-1;3;Illusion.Rendering.Editor.HybridLitShader;0;1;New Amplify Shader;368b90cdf7a92c5479634d4a85261b5e;True;MotionVectors;0;5;MotionVectors;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;5;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;True;True;False;False;0;False;;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=MotionVectors;False;False;0;;0;0;Standard;0;False;0
-Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;256;1897.124,-2215.099;Float;False;False;-1;3;Illusion.Rendering.Editor.HybridLitShader;0;1;New Amplify Shader;368b90cdf7a92c5479634d4a85261b5e;True;XRMotionVectors;0;6;XRMotionVectors;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;5;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;True;True;True;True;0;False;;False;False;False;False;False;False;False;True;True;1;False;;255;False;;1;False;;7;False;;3;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;False;False;False;True;1;LightMode=XRMotionVectors;False;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;2;0,0;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;1;New Amplify Shader;d7b9740d651f4f47a45c1ff0e4fac727;True;ShadowCaster;0;1;ShadowCaster;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;False;False;True;False;False;False;False;0;False;;False;False;False;False;False;False;False;False;False;True;1;False;;True;3;False;;False;True;1;LightMode=ShadowCaster;False;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;3;0,0;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;1;New Amplify Shader;d7b9740d651f4f47a45c1ff0e4fac727;True;DepthOnly;0;2;DepthOnly;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;False;False;True;False;False;False;False;0;False;;False;False;False;False;False;False;False;True;True;0;True;_StencilRefDepth;255;False;;255;True;_StencilWriteMaskDepth;7;False;;3;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;False;False;True;1;LightMode=DepthOnly;False;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;4;0,0;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;1;New Amplify Shader;d7b9740d651f4f47a45c1ff0e4fac727;True;Meta;0;3;Meta;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;2;False;;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=Meta;False;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;6;0,0;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;1;New Amplify Shader;d7b9740d651f4f47a45c1ff0e4fac727;True;GBuffer;0;4;GBuffer;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;True;1;5;False;;10;False;;1;1;False;;10;False;;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;True;True;True;True;0;False;;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;1;LightMode=UniversalGBuffer;False;True;12;d3d11;gles;metal;vulkan;xboxone;xboxseries;playstation;ps4;ps5;switch;switch2;webgpu;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;1;1897.124,-2275.099;Float;False;True;-1;2;AmplifyShaderEditor.MaterialInspector;0;21;Universal Render Pipeline/Water;d7b9740d651f4f47a45c1ff0e4fac727;True;Forward;0;0;Forward;21;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;2;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Transparent=RenderType;Queue=Transparent=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;True;1;5;False;;10;False;;1;1;False;;10;False;;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;True;True;True;True;0;False;;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;1;LightMode=UniversalForwardOnly;False;False;0;;0;0;Standard;50;Category;0;0;  Instanced Terrain Normals;1;0;Lighting Model;0;0;Workflow;1;0;Surface;1;638812485755269428;  Keep Alpha;0;0;  Refraction Model;0;0;  Blend;0;0;Two Sided;1;0;Alpha Clipping;1;0;  Use Shadow Threshold;0;0;Fragment Normal Space;0;0;Forward Only;1;638812485901019111;Transmission;0;0;  Transmission Shadow;0.5,False,;0;Translucency;0;0;  Translucency Strength;1,False,;0;  Normal Distortion;0.5,False,;0;  Scattering;2,False,;0;  Direct;0.9,False,;0;  Ambient;0.1,False,;0;  Shadow;0.5,False,;0;Cast Shadows;0;638812594748085911;Receive Shadows;1;0;Specular Highlights;2;0;Environment Reflections;2;0;Receive SSAO;1;0;Motion Vectors;1;0;  Add Precomputed Velocity;0;0;  XR Motion Vectors;0;0;GPU Instancing;1;0;LOD CrossFade;1;0;Built-in Fog;1;0;_FinalColorxAlpha;0;0;Meta Pass;0;638812485795591478;Override Baked GI;0;0;Tessellation;0;0;  Phong;0;0;  Strength;0.5,False,;0;  Type;0;0;  Tess;16,False,;0;  Min;10,False,;0;  Max;25,False,;0;  Edge Length;16,False,;0;  Max Displacement;25,False,;0;Write Depth;0;0;  Early Z;0;0;Vertex Position;1;0;Debug Display;0;0;Clear Coat;0;0;0;8;True;False;False;False;False;True;False;False;False;;True;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;252;1897.124,-1971.649;Float;False;False;-1;2;AmplifyShaderEditor.MaterialInspector;0;21;New Amplify Shader;d7b9740d651f4f47a45c1ff0e4fac727;True;WaterSSRData;0;7;WaterSSRData;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;3;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;2;False;;True;5;False;;False;True;1;LightMode=WaterSSRData;False;True;12;d3d11;gles;metal;vulkan;xboxone;xboxseries;playstation;ps4;ps5;switch;switch2;webgpu;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;255;1897.124,-2215.099;Float;False;False;-1;3;Illusion.Rendering.Editor.HybridLitShader;0;1;New Amplify Shader;d7b9740d651f4f47a45c1ff0e4fac727;True;MotionVectors;0;5;MotionVectors;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;5;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;True;True;False;False;0;False;;False;False;False;False;False;False;False;False;False;False;False;False;True;1;LightMode=MotionVectors;False;False;0;;0;0;Standard;0;False;0
+Node;AmplifyShaderEditor.TemplateMultiPassMasterNode, AmplifyShaderEditor, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null;256;1897.124,-2215.099;Float;False;False;-1;3;Illusion.Rendering.Editor.HybridLitShader;0;1;New Amplify Shader;d7b9740d651f4f47a45c1ff0e4fac727;True;XRMotionVectors;0;6;XRMotionVectors;0;False;False;False;False;False;False;False;False;False;False;False;False;True;0;False;;False;True;0;False;;False;False;False;False;False;False;False;False;False;True;False;0;False;;255;False;;255;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;True;1;False;;True;3;False;;True;True;0;False;;0;False;;True;4;RenderPipeline=UniversalPipeline;RenderType=Opaque=RenderType;Queue=Geometry=Queue=0;UniversalMaterialType=Lit;True;5;True;14;all;0;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;False;True;True;True;True;True;0;False;;False;False;False;False;False;False;False;True;True;1;False;;255;False;;1;False;;7;False;;3;False;;0;False;;0;False;;0;False;;0;False;;0;False;;0;False;;False;False;False;False;True;1;LightMode=XRMotionVectors;False;False;0;;0;0;Standard;0;False;0
 WireConnection;250;0;249;0
 WireConnection;187;0;250;3
 WireConnection;188;0;243;0
@@ -1477,4 +1625,4 @@ WireConnection;1;2;149;0
 WireConnection;1;6;196;0
 WireConnection;1;7;53;0
 ASEEND*/
-//CHKSM=4256EB6E0E9D0D897D088AFBBCC82DE6AAB689F3
+//CHKSM=59BF8886A4969230BE4FBA2A850D94B730928750

--- a/Shaders/Water/WaterShaderGraphFunctions.hlsl
+++ b/Shaders/Water/WaterShaderGraphFunctions.hlsl
@@ -4,6 +4,11 @@
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl"
 #include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/Water.hlsl"
 
+#if defined(ILLUSION_WATER_FORWARD_PASS)
+    #undef SHADERGRAPH_SAMPLE_SCENE_DEPTH
+    #define SHADERGRAPH_SAMPLE_SCENE_DEPTH(uv) SampleWaterSceneDepth(uv)
+#endif
+
 #undef SHADERGRAPH_SAMPLE_SCENE_COLOR
 #define SHADERGRAPH_SAMPLE_SCENE_COLOR(uv) shadergraph_WaterSampleSceneColor(ScreenPosNorm.xy, (uv), ScreenPos.w)
 

--- a/Shaders/Water/WaterShaderGraphFunctions.hlsl
+++ b/Shaders/Water/WaterShaderGraphFunctions.hlsl
@@ -1,0 +1,15 @@
+#ifndef ILLUSION_WATER_GRAPHFUNCTIONS_INCLUDED
+#define ILLUSION_WATER_GRAPHFUNCTIONS_INCLUDED
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderGraphFunctions.hlsl"
+#include "Packages/com.kurisu.illusion-render-pipelines/Shaders/Water/Water.hlsl"
+
+#undef SHADERGRAPH_SAMPLE_SCENE_COLOR
+#define SHADERGRAPH_SAMPLE_SCENE_COLOR(uv) shadergraph_WaterSampleSceneColor(ScreenPosNorm.xy, (uv), ScreenPos.w)
+
+float3 shadergraph_WaterSampleSceneColor(float2 currentUV, float2 distortedUV, float surfaceEyeDepth)
+{
+    return SamplePreRefractionColorDistorted(currentUV, distortedUV, surfaceEyeDepth);
+}
+
+#endif // ILLUSION_WATER_GRAPHFUNCTIONS_INCLUDED

--- a/Shaders/Water/WaterShaderGraphFunctions.hlsl.meta
+++ b/Shaders/Water/WaterShaderGraphFunctions.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 143fcbf35f3b47f0a44ca59a6f64b459
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

- Add dedicated `WaterSSRData` and pre-refraction color passes for transparent water SSR.
- Add an ASE Water Template with `Screen Space` and `Legacy` reflection modes.
- Preserve the legacy history-color raymarch path for compatibility and visual comparison.
- Add Transparent SSR settings, debugging support, DOTS instancing variants, and material pass synchronization.
- Correct SSR exposure and confidence blending in the Water shader.
- Add a pre-commit check for inconsistent line endings.