### PR TITLE
fix: rebuild stale convolution bloom OTF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Restore the established keyword stripping rules while retaining target-renderer-aware pass stripping.
 - Ignore inactive Illusion renderer features when gathering shader capabilities.
+- Fix Convolution Bloom producing invalid output after Editor startup or GPU resource recreation by rebuilding stale OTF data and preserving its RenderGraph dependencies.
+- Fix optimized high-quality convolution relying on compute shader keyword state leaked by a preceding OTF update.
 
 ## [1.2.4] - 2026-6-13
 

--- a/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/ConvolutionBloom.cs
+++ b/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/ConvolutionBloom.cs
@@ -53,6 +53,7 @@ namespace Illusion.Rendering.PostProcessing
         [Header("FFT")]
         public Vector2Parameter fftExtend = new(new Vector2(0.1f, 0.1f));
         
+        [Tooltip("Force the optical transfer function to be regenerated every frame. Normally it updates automatically when its source settings or GPU resource change.")]
         public BoolParameter updateOTF = new(false);
         
         public BoolParameter generatePSF = new(false);

--- a/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/ConvolutionBloomOtfState.cs
+++ b/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/ConvolutionBloomOtfState.cs
@@ -1,0 +1,132 @@
+using System;
+using UnityEngine;
+
+namespace Illusion.Rendering.PostProcessing
+{
+    internal readonly struct ConvolutionBloomOtfSettings : IEquatable<ConvolutionBloomOtfSettings>
+    {
+        internal readonly ConvolutionBloomQuality Quality;
+
+        internal readonly Vector2 FftExtend;
+
+        internal readonly bool GeneratePsf;
+
+        internal readonly Texture ImagePsf;
+
+        internal readonly float ImagePsfScale;
+
+        internal readonly float ImagePsfMinClamp;
+
+        internal readonly float ImagePsfMaxClamp;
+
+        internal readonly float ImagePsfPow;
+
+        internal ConvolutionBloomOtfSettings(
+            ConvolutionBloomQuality quality,
+            Vector2 fftExtend,
+            bool generatePsf,
+            Texture imagePsf,
+            float imagePsfScale,
+            float imagePsfMinClamp,
+            float imagePsfMaxClamp,
+            float imagePsfPow)
+        {
+            Quality = quality;
+            FftExtend = fftExtend;
+            GeneratePsf = generatePsf;
+            ImagePsf = imagePsf;
+            ImagePsfScale = imagePsfScale;
+            ImagePsfMinClamp = imagePsfMinClamp;
+            ImagePsfMaxClamp = imagePsfMaxClamp;
+            ImagePsfPow = imagePsfPow;
+        }
+
+        internal static ConvolutionBloomOtfSettings From(ConvolutionBloom settings)
+        {
+            return new ConvolutionBloomOtfSettings(
+                settings.quality.value,
+                settings.fftExtend.value,
+                settings.generatePSF.value,
+                settings.imagePSF.value,
+                settings.imagePSFScale.value,
+                settings.imagePSFMinClamp.value,
+                settings.imagePSFMaxClamp.value,
+                settings.imagePSFPow.value);
+        }
+
+        public bool Equals(ConvolutionBloomOtfSettings other)
+        {
+            return Quality == other.Quality
+                   && FftExtend.Equals(other.FftExtend)
+                   && GeneratePsf == other.GeneratePsf
+                   && ReferenceEquals(ImagePsf, other.ImagePsf)
+                   && ImagePsfScale.Equals(other.ImagePsfScale)
+                   && ImagePsfMinClamp.Equals(other.ImagePsfMinClamp)
+                   && ImagePsfMaxClamp.Equals(other.ImagePsfMaxClamp)
+                   && ImagePsfPow.Equals(other.ImagePsfPow);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is ConvolutionBloomOtfSettings other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = (int)Quality;
+                hashCode = (hashCode * 397) ^ FftExtend.GetHashCode();
+                hashCode = (hashCode * 397) ^ GeneratePsf.GetHashCode();
+                hashCode = (hashCode * 397) ^ (ImagePsf ? ImagePsf.GetInstanceID() : 0);
+                hashCode = (hashCode * 397) ^ ImagePsfScale.GetHashCode();
+                hashCode = (hashCode * 397) ^ ImagePsfMinClamp.GetHashCode();
+                hashCode = (hashCode * 397) ^ ImagePsfMaxClamp.GetHashCode();
+                hashCode = (hashCode * 397) ^ ImagePsfPow.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+
+    internal sealed class ConvolutionBloomOtfState
+    {
+        private bool _isValid;
+
+        private ConvolutionBloomOtfSettings _settings;
+
+        private uint _latestScheduledVersion;
+
+        internal bool RequiresUpdate(
+            in ConvolutionBloomOtfSettings settings,
+            bool resourceReallocated,
+            bool resourceCreated,
+            bool forceUpdate)
+        {
+            if (resourceReallocated || !resourceCreated)
+            {
+                _isValid = false;
+            }
+
+            return forceUpdate || !_isValid || !_settings.Equals(settings);
+        }
+
+        internal uint ScheduleUpdate()
+        {
+            return ++_latestScheduledVersion;
+        }
+
+        internal void MarkUpdated(in ConvolutionBloomOtfSettings settings, uint scheduledVersion)
+        {
+            if (scheduledVersion != _latestScheduledVersion) return;
+
+            _settings = settings;
+            _isValid = true;
+        }
+
+        internal void Reset()
+        {
+            _isValid = false;
+            ++_latestScheduledVersion;
+        }
+    }
+}

--- a/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/ConvolutionBloomOtfState.cs.meta
+++ b/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/ConvolutionBloomOtfState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 13b3ae8876c0cac42b8df8b30ea9556c

--- a/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/ConvolutionBloomPass.cs
+++ b/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/ConvolutionBloomPass.cs
@@ -18,11 +18,11 @@ namespace Illusion.Rendering.PostProcessing
 
         private RTHandle _fftTarget;
 
-        private RTHandle _psf;
-
         private RTHandle _otf;
         
         private RTHandle _imagePsfRTHandle;
+
+        private Texture _imagePsfTexture;
 
         private readonly LazyMaterial _brightMaskMaterial;
 
@@ -42,7 +42,7 @@ namespace Illusion.Rendering.PostProcessing
         
         private readonly ProfilingSampler _otfFftSampler = new("Convolution Bloom OTF FFT");
 
-        private bool _psfInitialized;
+        private readonly ConvolutionBloomOtfState _otfState = new();
 
         public ConvolutionBloomPass(IllusionRendererData rendererData)
         {
@@ -57,7 +57,7 @@ namespace Illusion.Rendering.PostProcessing
             ConfigureInput(ScriptableRenderPassInput.Color);
         }
 
-        private void UpdateRenderTextureSize(ConvolutionBloom bloomParam)
+        private bool UpdateRenderTextureSize(ConvolutionBloom bloomParam)
         {
             FFTKernel.FFTSize sizeX;
             FFTKernel.FFTSize sizeY;
@@ -88,7 +88,7 @@ namespace Illusion.Rendering.PostProcessing
                 enableRandomWrite = true,
                 useMipMap = false
             };
-            RenderingUtils.ReAllocateHandleIfNeeded(ref _otf, otfDesc, name: "ConvolutionBloom_OTF");
+            bool otfReallocated = RenderingUtils.ReAllocateHandleIfNeeded(ref _otf, otfDesc, name: "ConvolutionBloom_OTF");
 
             // Allocate FFT target texture
             var fftTargetDesc = new RenderTextureDescriptor(width, targetTexHeight, format, 0)
@@ -98,25 +98,19 @@ namespace Illusion.Rendering.PostProcessing
             };
             RenderingUtils.ReAllocateHandleIfNeeded(ref _fftTarget, fftTargetDesc, wrapMode: TextureWrapMode.Clamp, name: "ConvolutionBloom_FFTTarget");
 
-            // Allocate PSF texture
-            var psfDesc = new RenderTextureDescriptor(width, height, format, 0)
-            {
-                enableRandomWrite = true,
-                useMipMap = false
-            };
-            RenderingUtils.ReAllocateHandleIfNeeded(ref _psf, psfDesc, name: "ConvolutionBloom_PSF");
+            return otfReallocated;
         }
 
         public void Dispose()
         {
-            _psf?.Release();
-            _psf = null;
             _otf?.Release();
             _otf = null;
             _fftTarget?.Release();
             _fftTarget = null;
             _imagePsfRTHandle?.Release();
             _imagePsfRTHandle = null;
+            _imagePsfTexture = null;
+            _otfState.Reset();
             
             _brightMaskMaterial.DestroyCache();
             _bloomBlendMaterial.DestroyCache();
@@ -159,10 +153,18 @@ namespace Illusion.Rendering.PostProcessing
         {
             internal Material PsfRemapMaterial;
             internal Material PsfGeneratorMaterial;
+            internal Vector2 FftExtend;
+            internal float ImagePsfScale;
+            internal float ImagePsfMinClamp;
+            internal float ImagePsfMaxClamp;
+            internal float ImagePsfPow;
             internal bool HighQuality;
             internal FFTKernel FFTKernel;
             internal TextureHandle OtfTextureHandle;
             internal TextureHandle ImagePsfTexture;
+            internal ConvolutionBloomOtfState OtfState;
+            internal ConvolutionBloomOtfSettings OtfSettings;
+            internal uint ScheduledVersion;
         }
 
         public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
@@ -178,21 +180,29 @@ namespace Illusion.Rendering.PostProcessing
             bool highQuality = bloomParams.quality.value == ConvolutionBloomQuality.High;
             if (!bloomParams.disableReadWriteOptimization.value) fftExtend.y = 0;
             
-            UpdateRenderTextureSize(bloomParams);
+            var otfSettings = ConvolutionBloomOtfSettings.From(bloomParams);
+            bool otfReallocated = UpdateRenderTextureSize(bloomParams);
+            bool otfResourceCreated = _otf?.rt != null && _otf.rt.IsCreated();
 
             var resource = frameData.Get<UniversalResourceData>();
             TextureHandle colorTexture = resource.activeColorTexture;
+
+            // Import the OTF exactly once so RenderGraph can track PSF -> FFT -> convolution dependencies.
+            TextureHandle otfHandle = renderGraph.ImportTexture(_otf);
             
-            // Update OTF if parameters changed
-            if (bloomParams.IsParamUpdated() || !_psfInitialized)
+            bool updateOtf = _otfState.RequiresUpdate(
+                otfSettings,
+                otfReallocated,
+                otfResourceCreated,
+                bloomParams.IsParamUpdated());
+            if (updateOtf)
             {
-                _psfInitialized = true;
-                RenderOTFUpdatePass(renderGraph, bloomParams, highQuality);
+                uint scheduledVersion = _otfState.ScheduleUpdate();
+                RenderOTFUpdatePass(renderGraph, otfHandle, otfSettings, highQuality, scheduledVersion);
             }
             
-            // Import RTHandles as TextureHandles
+            // Import the per-frame FFT target.
             TextureHandle fftTargetHandle = renderGraph.ImportTexture(_fftTarget);
-            TextureHandle otfHandle = renderGraph.ImportTexture(_otf);
 
             // Pass 1: Bright mask extraction
             fftTargetHandle = RenderBrightMaskPass(renderGraph, colorTexture, fftTargetHandle, threshold, thresholdKnee, clampMax, fftExtend);
@@ -252,7 +262,7 @@ namespace Illusion.Rendering.PostProcessing
 
                 // Mark textures as used in the pass
                 builder.UseTexture(fftTarget, AccessFlags.ReadWrite);
-                builder.UseTexture(ortFilter, AccessFlags.ReadWrite);
+                builder.UseTexture(ortFilter, AccessFlags.Read);
 
                 builder.AllowPassCulling(false);
                 builder.AllowGlobalStateModification(true);
@@ -273,7 +283,8 @@ namespace Illusion.Rendering.PostProcessing
                             verticalRange = new Vector2Int(0, ((RTHandle)data.Target).rt.height);
                             offset = new Vector2Int(0, -paddingY);
                         }
-                        data.FFTKernel.ConvolveOpt(context.cmd, data.Target, data.Filter, data.Size, Vector2Int.zero, verticalRange, offset);
+                        data.FFTKernel.ConvolveOpt(context.cmd, data.Target, data.Filter, data.Size,
+                            Vector2Int.zero, verticalRange, offset, data.HighQuality);
                     }
                 });
 
@@ -306,49 +317,54 @@ namespace Illusion.Rendering.PostProcessing
             }
         }
 
-        private void RenderOTFUpdatePass(RenderGraph renderGraph, ConvolutionBloom param, bool highQuality)
+        private void RenderOTFUpdatePass(RenderGraph renderGraph, TextureHandle otfHandle,
+            in ConvolutionBloomOtfSettings settings, bool highQuality, uint scheduledVersion)
         {
-            TextureHandle otfHandle = renderGraph.ImportTexture(_otf);
-            
             // PSF Remap/Generation Pass (Raster)
             using (var builder = renderGraph.AddRasterRenderPass<OTFUpdatePassData>("Convolution Bloom OTF PSF", out var passData, _otfPsfSampler))
             {
                 passData.PsfRemapMaterial = _psfRemapMaterial.Value;
                 passData.PsfGeneratorMaterial = _psfGeneratorMaterial.Value;
+                passData.FftExtend = settings.FftExtend;
+                passData.ImagePsfScale = settings.ImagePsfScale;
+                passData.ImagePsfMinClamp = settings.ImagePsfMinClamp;
+                passData.ImagePsfMaxClamp = settings.ImagePsfMaxClamp;
+                passData.ImagePsfPow = settings.ImagePsfPow;
                 builder.SetRenderAttachment(otfHandle, 0);
                 passData.OtfTextureHandle = otfHandle;
                 
                 builder.AllowPassCulling(false);
                 
-                if (!param.generatePSF.value && param.imagePSF.value)
+                if (!settings.GeneratePsf && settings.ImagePsf)
                 {
                     // Cache RTHandle for imagePSF texture
-                    if (_imagePsfRTHandle == null || _imagePsfRTHandle.rt != param.imagePSF.value)
+                    if (_imagePsfRTHandle == null || !ReferenceEquals(_imagePsfTexture, settings.ImagePsf))
                     {
                         _imagePsfRTHandle?.Release();
-                        _imagePsfRTHandle = RTHandles.Alloc(param.imagePSF.value);
+                        _imagePsfTexture = settings.ImagePsf;
+                        _imagePsfRTHandle = RTHandles.Alloc(settings.ImagePsf);
                     }
 
                     var psf = renderGraph.ImportTexture(_imagePsfRTHandle);
                     builder.UseTexture(psf);
                     passData.ImagePsfTexture = psf;
-                    passData.PsfRemapMaterial.SetFloat(ShaderProperties.MaxClamp, param.imagePSFMaxClamp.value);
-                    passData.PsfRemapMaterial.SetFloat(ShaderProperties.MinClamp, param.imagePSFMinClamp.value);
-                    passData.PsfRemapMaterial.SetVector(ShaderProperties.FFTExtend, param.fftExtend.value);
-                    passData.PsfRemapMaterial.SetFloat(ShaderProperties.KernelPow, param.imagePSFPow.value);
-                    passData.PsfRemapMaterial.SetFloat(ShaderProperties.KernelScaler, param.imagePSFScale.value);
-                    passData.PsfRemapMaterial.SetInt(ShaderProperties.EnableRemap, 1);
                     builder.SetRenderFunc(static (OTFUpdatePassData data, RasterGraphContext context) =>
                     {
+                        data.PsfRemapMaterial.SetFloat(ShaderProperties.MaxClamp, data.ImagePsfMaxClamp);
+                        data.PsfRemapMaterial.SetFloat(ShaderProperties.MinClamp, data.ImagePsfMinClamp);
+                        data.PsfRemapMaterial.SetVector(ShaderProperties.FFTExtend, data.FftExtend);
+                        data.PsfRemapMaterial.SetFloat(ShaderProperties.KernelPow, data.ImagePsfPow);
+                        data.PsfRemapMaterial.SetFloat(ShaderProperties.KernelScaler, data.ImagePsfScale);
+                        data.PsfRemapMaterial.SetInt(ShaderProperties.EnableRemap, 1);
                         Blitter.BlitTexture(context.cmd, data.ImagePsfTexture, Vector2.one, data.PsfRemapMaterial, 0);
                     });
                 }
                 else
                 {
-                    passData.PsfGeneratorMaterial.SetVector(ShaderProperties.FFTExtend, param.fftExtend.value);
-                    passData.PsfGeneratorMaterial.SetInt(ShaderProperties.EnableRemap, 1);
                     builder.SetRenderFunc(static (OTFUpdatePassData data, RasterGraphContext context) =>
                     {
+                        data.PsfGeneratorMaterial.SetVector(ShaderProperties.FFTExtend, data.FftExtend);
+                        data.PsfGeneratorMaterial.SetInt(ShaderProperties.EnableRemap, 1);
                         Blitter.BlitTexture(context.cmd, Vector2.one, data.PsfGeneratorMaterial, 0);
                     });
                 }
@@ -359,6 +375,9 @@ namespace Illusion.Rendering.PostProcessing
             {
                 passData.FFTKernel = _fftKernel;
                 passData.HighQuality = highQuality;
+                passData.OtfState = _otfState;
+                passData.OtfSettings = settings;
+                passData.ScheduledVersion = scheduledVersion;
                 builder.UseTexture(otfHandle, AccessFlags.ReadWrite);
                 passData.OtfTextureHandle = otfHandle;
 
@@ -368,6 +387,7 @@ namespace Illusion.Rendering.PostProcessing
                 builder.SetRenderFunc(static (OTFUpdatePassData data, ComputeGraphContext context) =>
                 {
                     data.FFTKernel.FFT(context.cmd, data.OtfTextureHandle, data.HighQuality);
+                    data.OtfState.MarkUpdated(data.OtfSettings, data.ScheduledVersion);
                 });
             }
         }

--- a/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/FFTKernel.cs
+++ b/Runtime/RenderPipeline/PostProcessing/ConvolutionBloom/FFTKernel.cs
@@ -118,7 +118,7 @@ namespace Illusion.Rendering.PostProcessing
 
         private void InternalFFT(CommandBuffer cmd, RTHandle texture, bool highQuality)
         {
-            _fftShader.EnableKeyword(_keywordInoutTarget);
+            cmd.EnableKeyword(_fftShader, _keywordInoutTarget);
             cmd.SetComputeTextureParam(_fftShader, _fftKernel, ShaderIds.Target, texture);
             UpdateSize(texture.rt.width, texture.rt.height);
 
@@ -135,6 +135,8 @@ namespace Illusion.Rendering.PostProcessing
             cmd.EnableKeyword(_fftShader, _keywordVertical);
             cmd.DispatchCompute(_fftShader, _fftKernel, 1, _sizeX, 1);
             cmd.DisableKeyword(_fftShader, _keywordVertical);
+            cmd.DisableKeyword(_fftShader, _keywordHighQuality);
+            cmd.DisableKeyword(_fftShader, _keywordInoutTarget);
         }
 
         public void FFT(CommandBuffer cmd, RTHandle texture, bool highQuality)
@@ -176,6 +178,19 @@ namespace Illusion.Rendering.PostProcessing
             Vector2Int verticalRange,
             Vector2Int offset)
         {
+            ConvolveOpt(cmd, texture, filter, size, horizontalRange, verticalRange, offset,
+                size.x == (int)FFTSize.Size1024);
+        }
+
+        public void ConvolveOpt(CommandBuffer cmd,
+            RTHandle texture,
+            RTHandle filter,
+            Vector2Int size,
+            Vector2Int horizontalRange,
+            Vector2Int verticalRange,
+            Vector2Int offset,
+            bool highQuality)
+        {
             int rwRangeBeginX = horizontalRange[0];
             int rwRangeEndX = horizontalRange[1];
             int rwRangeBeginY = verticalRange[0];
@@ -185,6 +200,14 @@ namespace Illusion.Rendering.PostProcessing
             bool verticalOffset = offset.y != 0;
 
             cmd.EnableKeyword(_fftShader, _keywordInoutTarget);
+            if (highQuality)
+            {
+                cmd.EnableKeyword(_fftShader, _keywordHighQuality);
+            }
+            else
+            {
+                cmd.DisableKeyword(_fftShader, _keywordHighQuality);
+            }
             cmd.SetComputeTextureParam(_fftShader, _fftKernel, ShaderIds.Target, texture);
             UpdateSize(size.x, size.y);
 
@@ -267,6 +290,9 @@ namespace Illusion.Rendering.PostProcessing
                     cmd.DisableKeyword(_fftShader, _keywordWriteBlock);
                 }
             }
+
+            cmd.DisableKeyword(_fftShader, _keywordHighQuality);
+            cmd.DisableKeyword(_fftShader, _keywordInoutTarget);
         }
                 
         public void FFT(ComputeCommandBuffer cmd, TextureHandle texture, bool highQuality)
@@ -285,7 +311,7 @@ namespace Illusion.Rendering.PostProcessing
         
         private void InternalFFT(ComputeCommandBuffer cmd, TextureHandle texture, bool highQuality)
         {
-            _fftShader.EnableKeyword(_keywordInoutTarget);
+            cmd.EnableKeyword(_fftShader, _keywordInoutTarget);
             cmd.SetComputeTextureParam(_fftShader, _fftKernel, ShaderIds.Target, texture);
             RTHandle rt = texture;
             UpdateSize(rt.rt.width, rt.rt.height);
@@ -303,6 +329,8 @@ namespace Illusion.Rendering.PostProcessing
             cmd.EnableKeyword(_fftShader, _keywordVertical);
             cmd.DispatchCompute(_fftShader, _fftKernel, 1, _sizeX, 1);
             cmd.DisableKeyword(_fftShader, _keywordVertical);
+            cmd.DisableKeyword(_fftShader, _keywordHighQuality);
+            cmd.DisableKeyword(_fftShader, _keywordInoutTarget);
         }
                 
         public void Convolve(ComputeCommandBuffer cmd, TextureHandle texture, TextureHandle filter, bool highQuality)
@@ -330,6 +358,19 @@ namespace Illusion.Rendering.PostProcessing
             Vector2Int verticalRange,
             Vector2Int offset)
         {
+            ConvolveOpt(cmd, texture, filter, size, horizontalRange, verticalRange, offset,
+                size.x == (int)FFTSize.Size1024);
+        }
+
+        public void ConvolveOpt(ComputeCommandBuffer cmd,
+            TextureHandle texture,
+            TextureHandle filter,
+            Vector2Int size,
+            Vector2Int horizontalRange,
+            Vector2Int verticalRange,
+            Vector2Int offset,
+            bool highQuality)
+        {
             int rwRangeBeginX = horizontalRange[0];
             int rwRangeEndX = horizontalRange[1];
             int rwRangeBeginY = verticalRange[0];
@@ -339,6 +380,14 @@ namespace Illusion.Rendering.PostProcessing
             bool verticalOffset = offset.y != 0;
 
             cmd.EnableKeyword(_fftShader, _keywordInoutTarget);
+            if (highQuality)
+            {
+                cmd.EnableKeyword(_fftShader, _keywordHighQuality);
+            }
+            else
+            {
+                cmd.DisableKeyword(_fftShader, _keywordHighQuality);
+            }
             cmd.SetComputeTextureParam(_fftShader, _fftKernel, ShaderIds.Target, texture);
             UpdateSize(size.x, size.y);
 
@@ -422,6 +471,9 @@ namespace Illusion.Rendering.PostProcessing
                     cmd.DisableKeyword(_fftShader, _keywordWriteBlock);
                 }
             }
+
+            cmd.DisableKeyword(_fftShader, _keywordHighQuality);
+            cmd.DisableKeyword(_fftShader, _keywordInoutTarget);
         }
         
         private static class ShaderIds


### PR DESCRIPTION
## Summary

Fix Convolution Bloom producing invalid output after Unity Editor startup or GPU resource recreation.

- Rebuild stale OTF data when its resource or source settings change.
- Preserve OTF dependencies through the RenderGraph passes.
- Explicitly manage FFT compute shader keywords for optimized high-quality convolution.
- Remove the unused PSF render texture.