### PR TITLE
feat: Support directional light sources for per-object shadows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add renderer-level World Scale conversion across IllusionRP world-space effects.
+- Add camera-level selection of the directional light used by per-object shadows, including Forward+ additional directional lights.
 
 ## [1.2.5] - 2026-8-10
 

--- a/Documentation~/Lighting.md
+++ b/Documentation~/Lighting.md
@@ -49,6 +49,15 @@ You can add the **Illusion/Per Object Shadows** Volume component to configure gl
 
 Per Object Shadows are automatically combined with the main directional light shadow map in the Screen Space Shadows pass. This enables advanced shadow filtering techniques like PCSS to work with per-object shadows.
 
+### Additional Directional Light Source
+
+Enable **Additional Directional Per-Object Shadows** in the **Illusion Graphics** renderer feature to allow a camera to select a Forward+ additional directional light:
+
+1. Add `PerObjectShadowLightSource` to the Camera.
+2. Assign an enabled Directional Light with shadows to **Source**.
+
+A missing, disabled, or unassigned component follows the camera's URP Main Light. An assigned source that is temporarily invalid disables Per Object Shadows for that frame instead of falling back to Main. Disable the renderer feature option to ignore camera overrides and use the lower-cost, Main-only single-channel screen-space shadow path.
+
 > [!TIP]
 > Per Object Shadows work seamlessly with PCSS. When PCSS is enabled, per-object shadows receive the same soft penumbra filtering as the main light shadows.
 

--- a/Editor/RenderPipeline/IllusionRendererFeatureEditor.cs
+++ b/Editor/RenderPipeline/IllusionRendererFeatureEditor.cs
@@ -27,6 +27,7 @@ namespace Illusion.Rendering.Editor
 
         // Shadow Settings
         private SerializedProperty _perObjectShadowRenderingLayer;
+        private SerializedProperty _additionalDirectionalPerObjectShadows;
         private SerializedProperty _transparentReceivePerObjectShadows;
         private SerializedProperty _contactShadows;
         private SerializedProperty _pcssShadows;
@@ -69,6 +70,7 @@ namespace Illusion.Rendering.Editor
 
             // Shadow Settings
             _perObjectShadowRenderingLayer = Properties.Find(feature => feature.perObjectShadowRenderingLayer);
+            _additionalDirectionalPerObjectShadows = Properties.Find(feature => feature.additionalDirectionalPerObjectShadows);
             _transparentReceivePerObjectShadows = Properties.Find(feature => feature.transparentReceivePerObjectShadows);
             _contactShadows = Properties.Find(feature => feature.contactShadows);
             _pcssShadows = Properties.Find(feature => feature.pcssShadows);
@@ -165,6 +167,8 @@ namespace Illusion.Rendering.Editor
             if (Foldout("Shadows", true))
             {
                 EditorGUILayout.PropertyField(_perObjectShadowRenderingLayer, Styles.PerObjectShadowRenderingLayerLabel);
+                EditorGUILayout.PropertyField(_additionalDirectionalPerObjectShadows,
+                    Styles.AdditionalDirectionalPerObjectShadowsLabel);
                 EditorGUILayout.PropertyField(_transparentReceivePerObjectShadows, Styles.TransparentReceivePerObjectShadowsLabel);
                 EditorGUILayout.PropertyField(_pcssShadows, Styles.PcssShadowsLabel);
                 EditorGUILayout.PropertyField(_contactShadows, Styles.ContactShadowsLabel);
@@ -242,6 +246,9 @@ namespace Illusion.Rendering.Editor
             // Shadow Settings
             public static readonly GUIContent PerObjectShadowRenderingLayerLabel = new("Per Object Shadow Rendering Layer",
                 "Rendering layer for per object shadow to prevent shadow overdraw in main light caster.");
+            public static readonly GUIContent AdditionalDirectionalPerObjectShadowsLabel = new(
+                "Additional Directional Per-Object Shadows",
+                "Allow a camera to use an additional directional light for per-object shadows.");
             public static readonly GUIContent TransparentReceivePerObjectShadowsLabel = new("Transparent Receive Per Object Shadows",
                 "When enabled, transparent objects will sample per object shadow.");
             public static readonly GUIContent ContactShadowsLabel = new("Contact Shadows",

--- a/Runtime/RenderPipeline/IllusionRendererData.cs
+++ b/Runtime/RenderPipeline/IllusionRendererData.cs
@@ -353,6 +353,8 @@ namespace Illusion.Rendering
 
         public uint PerObjectShadowRenderingLayer { get; internal set; }
 
+        public bool AdditionalDirectionalPerObjectShadows { get; internal set; }
+
         public MipGenerator MipGenerator { get; }
 
         public const int ShadowCascadeCount = 4;
@@ -406,6 +408,9 @@ namespace Illusion.Rendering
         {
             public bool HasDirectionalHistoryState;
             public Vector3 LastMainLightDirection;
+            public PerObjectShadowLightMode LastPerObjectShadowMode;
+            public int LastPerObjectLightId;
+            public Vector3 LastPerObjectLightDirection;
             public uint LastHistoryFrameCount;
             public bool ActiveThisFrame;
             public bool HistoryValidThisFrame;
@@ -482,8 +487,6 @@ namespace Illusion.Rendering
         
         private RTHandle _grayTextureRTHandle;
 
-        private UniversalAdditionalLightData _mainLightData;
-
         private const GraphicsFormat ExposureFormat = GraphicsFormat.R32G32_SFloat;
 
         private ComputeBuffer _ambientProbeBuffer;
@@ -551,7 +554,6 @@ namespace Illusion.Rendering
             _currentCameraState.BeginFrame();
             _currentCameraState.IsFirstFrame = false;
             PruneStaleCameraStates();
-            UpdateLightData(lightData);
             UpdateShadowData(cameraData, lightData, shadowData);
             UpdateRenderTextures(cameraData);
             UpdateDebugSettings(cameraData);
@@ -668,8 +670,13 @@ namespace Illusion.Rendering
             int mainLightIndex = lightData.mainLightIndex;
             if (mainLightIndex < 0) return; // No main light
             VisibleLight mainLight = lightData.visibleLights[mainLightIndex];
-            intensity = mainLight.light.bounceIntensity;
-            renderingLayers = _mainLightData?.renderingLayers ?? 0;
+            Light light = mainLight.light;
+            if (!light) return;
+
+            intensity = light.bounceIntensity;
+            renderingLayers = light.TryGetComponent(out UniversalAdditionalLightData additionalLightData)
+                ? additionalLightData.renderingLayers
+                : unchecked((uint)light.renderingLayerMask);
         }
 
         private void UpdateDebugSettings(UniversalCameraData cameraData)
@@ -894,29 +901,6 @@ namespace Illusion.Rendering
                     cameraState.Dispose();
 
                 _cameraStates.Remove(key);
-            }
-        }
-
-        private void UpdateLightData(UniversalLightData lightData)
-        {
-            int mainLightIndex = lightData.mainLightIndex;
-            if (mainLightIndex < 0) return; // No main light
-
-            VisibleLight mainLight = lightData.visibleLights[mainLightIndex];
-            if (_mainLightData == null || _mainLightData.gameObject != mainLight.light.gameObject)
-            {
-                if (!mainLight.light) return;
-                // Prevent main light overdraw shadow.
-                if (!mainLight.light.TryGetComponent(out _mainLightData)) return;
-                if (_mainLightData.customShadowLayers)
-                {
-                    _mainLightData.shadowRenderingLayers &= ~PerObjectShadowRenderingLayer;
-                }
-                else
-                {
-                    _mainLightData.customShadowLayers = true;
-                    _mainLightData.shadowRenderingLayers = uint.MaxValue & ~PerObjectShadowRenderingLayer;
-                }
             }
         }
 

--- a/Runtime/RenderPipeline/IllusionRendererFeature.cs
+++ b/Runtime/RenderPipeline/IllusionRendererFeature.cs
@@ -93,6 +93,11 @@ namespace Illusion.Rendering
         internal RenderingLayerMask perObjectShadowRenderingLayer;
 
         /// <summary>
+        /// Allow cameras to select an additional directional light as their per-object shadow source.
+        /// </summary>
+        public bool additionalDirectionalPerObjectShadows = true;
+
+        /// <summary>
         /// When enabled, transparent objects will sample per object shadow which will decrease performance."
         /// </summary>
         public bool transparentReceivePerObjectShadows;
@@ -236,6 +241,8 @@ namespace Illusion.Rendering
 
         private SetupPass _setupPass;
 
+        private PerObjectShadowMainLightCasterScope _mainLightCasterScope;
+
         private AdvancedTonemappingPass _advancedTonemappingPass;
 
         private ExposurePass _exposurePass;
@@ -283,6 +290,8 @@ namespace Illusion.Rendering
             }
             _rendererData = new IllusionRendererData(_renderPipelineResources);
             UpdateRenderDataSettings();
+            _mainLightCasterScope = new PerObjectShadowMainLightCasterScope(
+                additionalDirectionalPerObjectShadows, perObjectShadowRenderingLayer);
 
             _sceneShadowCasterManager = new ShadowCasterManager();
 
@@ -361,6 +370,11 @@ namespace Illusion.Rendering
             _stencilVRSDebugPass = new StencilVRSDebugPass();
             _transparentSSRDebugPass = new TransparentSSRDebugPass(_rendererData);
 #endif
+        }
+
+        public override void OnCameraPreCull(ScriptableRenderer renderer, in CameraData cameraData)
+        {
+            _mainLightCasterScope?.BeginCameraCull(cameraData.camera, renderer);
         }
 
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
@@ -666,12 +680,17 @@ namespace Illusion.Rendering
             rendererData.RequireHistoryDepthNormal = useScreenSpaceGlobalIllumination || useShadowTemporalAccumulation;
 
             var shadow = VolumeManager.instance.stack.GetComponent<PerObjectShadows>();
-            _sceneShadowCasterManager.Cull(cameraData, lightData,
+            bool supportsAdditionalDirectional =
+                UniversalRenderingUtility.GetRenderingModeActual(cameraData.renderer) == RenderingMode.ForwardPlus;
+            PerObjectShadowLightData perObjectShadowLight =
+                PerObjectShadowLightData.Resolve(cameraData, lightData,
+                    additionalDirectionalPerObjectShadows, supportsAdditionalDirectional);
+            _sceneShadowCasterManager.Cull(cameraData, in perObjectShadowLight,
                 PerObjectShadowCasterPass.MaxShadowCount,
                 shadow.perObjectShadowLengthOffset.value,
                 IllusionRuntimeRenderingConfig.Get().EnablePerObjectShadowDebug);
             _perObjShadowPass.Setup(_sceneShadowCasterManager, shadow.perObjectShadowTileResolution.value,
-                shadow.perObjectShadowDepthBits.value);
+                shadow.perObjectShadowDepthBits.value, in perObjectShadowLight);
             _volumetricFogPass.Setup(_volumetricLightManager);
         }
 
@@ -679,6 +698,9 @@ namespace Illusion.Rendering
         {
             var config = IllusionRuntimeRenderingConfig.Get();
             _rendererData.PerObjectShadowRenderingLayer = perObjectShadowRenderingLayer;
+            _rendererData.AdditionalDirectionalPerObjectShadows = additionalDirectionalPerObjectShadows;
+            _mainLightCasterScope?.UpdateSettings(
+                additionalDirectionalPerObjectShadows, perObjectShadowRenderingLayer);
             _rendererData.WorldScale = Mathf.Max(0.001f, worldScale);
             // We should check compute shaders are supported whether we should fall back to fragment shader.
             // But currently IllusionRP only supports platforms that support compute shader.
@@ -697,6 +719,7 @@ namespace Illusion.Rendering
 
         private void Release()
         {
+            SafeDispose(ref _mainLightCasterScope);
             SafeDispose(ref _rendererData);
             SafeDispose(ref _diffuseShadowDenoisePass);
             SafeDispose(ref _groundTruthAmbientOcclusionPass);

--- a/Runtime/RenderPipeline/Shadows/ContactShadows/DiffuseShadowDenoiser.cs
+++ b/Runtime/RenderPipeline/Shadows/ContactShadows/DiffuseShadowDenoiser.cs
@@ -18,12 +18,18 @@ namespace Illusion.Rendering.Shadows
         
         private readonly int _bilateralFilterVSingleDirectionalKernel;
 
+        private readonly int _bilateralFilterHColorDirectionalKernel;
+
+        private readonly int _bilateralFilterVColorDirectionalKernel;
+
         public DiffuseShadowDenoiser(ComputeShader shadowDenoiserCS)
         {
             _shadowDenoiser = shadowDenoiserCS;
 
             _bilateralFilterHSingleDirectionalKernel = _shadowDenoiser.FindKernel("BilateralFilterHSingleDirectional");
             _bilateralFilterVSingleDirectionalKernel = _shadowDenoiser.FindKernel("BilateralFilterVSingleDirectional");
+            _bilateralFilterHColorDirectionalKernel = _shadowDenoiser.FindKernel("BilateralFilterHColorDirectional");
+            _bilateralFilterVColorDirectionalKernel = _shadowDenoiser.FindKernel("BilateralFilterVColorDirectional");
         }
 
         /// <summary>
@@ -128,7 +134,7 @@ namespace Illusion.Rendering.Shadows
             TextureHandle noisyBuffer, TextureHandle intermediateBuffer, TextureHandle outputBuffer,
             int texWidth, int texHeight, int viewCount,
             float lightAngle, float cameraFov, int kernelSize,
-            ProfilingSampler profilingSampler)
+            ProfilingSampler profilingSampler, bool color = false)
         {
             using (var builder = renderGraph.AddComputePass<DenoisePassData>("Diffuse Shadow Denoise", out var passData, profilingSampler))
             {
@@ -143,8 +149,12 @@ namespace Illusion.Rendering.Shadows
                 passData.KernelSize = kernelSize;
 
                 // Kernels
-                passData.BilateralHKernel = _bilateralFilterHSingleDirectionalKernel;
-                passData.BilateralVKernel = _bilateralFilterVSingleDirectionalKernel;
+                passData.BilateralHKernel = color
+                    ? _bilateralFilterHColorDirectionalKernel
+                    : _bilateralFilterHSingleDirectionalKernel;
+                passData.BilateralVKernel = color
+                    ? _bilateralFilterVColorDirectionalKernel
+                    : _bilateralFilterVSingleDirectionalKernel;
 
                 // Other parameters
                 passData.DiffuseShadowDenoiserCs = _shadowDenoiser;

--- a/Runtime/RenderPipeline/Shadows/PerObjectShadow/PerObjectShadowCasterPass.cs
+++ b/Runtime/RenderPipeline/Shadows/PerObjectShadow/PerObjectShadowCasterPass.cs
@@ -45,7 +45,7 @@ namespace Illusion.Rendering.Shadows
 
         private RTHandle _shadowMap;
 
-        private UniversalAdditionalLightData _mainLightData;
+        private PerObjectShadowLightData _lightData;
 
         // Per-object shadow PCSS parameters
         private readonly Vector4[] _perObjShadowPcssParams0;
@@ -77,10 +77,12 @@ namespace Illusion.Rendering.Shadows
             _shadowMap?.Release();
         }
 
-        public void Setup(ShadowCasterManager casterManager, ShadowTileResolution tileResolution, DepthBits depthBits)
+        public void Setup(ShadowCasterManager casterManager, ShadowTileResolution tileResolution, DepthBits depthBits,
+            in PerObjectShadowLightData lightData)
         {
             _casterManager = casterManager;
             _tileResolution = (int)tileResolution;
+            _lightData = lightData;
 
             if (casterManager.VisibleCount <= 0)
             {
@@ -99,8 +101,9 @@ namespace Illusion.Rendering.Shadows
         {
             internal PerObjectShadowCasterPass Pass;
             internal TextureHandle ShadowmapTexture;
-            internal UniversalLightData LightData;
-            internal UniversalShadowData ShadowData;
+            internal PerObjectShadowLightData LightData;
+            internal Vector2 ShadowBias;
+            internal bool SupportsSoftShadows;
             internal ShadowCasterManager CasterManager;
             internal int ShadowMapSizeInTile;
             internal int TileResolution;
@@ -118,8 +121,6 @@ namespace Illusion.Rendering.Shadows
         {
             var resource = frameData.Get<UniversalResourceData>();
             var cameraData = frameData.Get<UniversalCameraData>();
-            var lightData = frameData.Get<UniversalLightData>();
-            var shadowData = frameData.Get<UniversalShadowData>();
             if (_casterManager.VisibleCount <= 0)
             {
                 // No shadows to render, set shadow count to 0
@@ -133,6 +134,9 @@ namespace Illusion.Rendering.Shadows
                     builder.SetRenderFunc((PassData data, RasterGraphContext context) =>
                     {
                         context.cmd.SetGlobalInt(PropertyIds.ShadowCount(), 0);
+                        context.cmd.SetGlobalInt(PropertyIds.SourceMode(), (int)data.Pass._lightData.Mode);
+                        context.cmd.SetGlobalInt(PropertyIds.AdditionalLightIndex(), data.Pass._lightData.AdditionalLightIndex);
+                        context.cmd.SetGlobalVector(PropertyIds.LightDirection(), GetLightDirection(data.Pass._lightData));
                     });
                 }
                 return;
@@ -142,7 +146,7 @@ namespace Illusion.Rendering.Shadows
             TextureHandle shadowTexture;
             using (var builder = renderGraph.AddRasterRenderPass<PassData>("Per-Object Shadowmap", out var passData, profilingSampler))
             {
-                InitPassData(ref passData, lightData, shadowData);
+                InitPassData(ref passData);
                 
                 passData.ShadowmapTexture = UniversalRenderer.CreateRenderGraphTexture(renderGraph, _shadowMap.rt.descriptor, "_MainLightPerObjectShadow", true);
                 builder.SetRenderAttachmentDepth(passData.ShadowmapTexture);
@@ -161,7 +165,7 @@ namespace Illusion.Rendering.Shadows
             // Pass 2: Set global shadow properties
             using (var builder = renderGraph.AddRasterRenderPass<PassData>("Set Per-Object Shadow Globals", out var passData, profilingSampler))
             {
-                InitPassData(ref passData, lightData, shadowData);
+                InitPassData(ref passData);
                 passData.ShadowmapTexture = shadowTexture;
                 
                 if (shadowTexture.IsValid())
@@ -181,11 +185,12 @@ namespace Illusion.Rendering.Shadows
             renderer.SetupRenderGraphCameraProperties(renderGraph, resource.activeColorTexture);
         }
 
-        private void InitPassData(ref PassData passData, UniversalLightData lightData, UniversalShadowData shadowData)
+        private void InitPassData(ref PassData passData)
         {
             passData.Pass = this;
-            passData.LightData = lightData;
-            passData.ShadowData = shadowData;
+            passData.LightData = _lightData;
+            passData.ShadowBias = ResolveShadowBias(_lightData.VisibleLight.light, out bool supportsSoftShadows);
+            passData.SupportsSoftShadows = supportsSoftShadows;
             passData.CasterManager = _casterManager;
             passData.ShadowMapSizeInTile = _shadowMapSizeInTile;
             passData.TileResolution = _tileResolution;
@@ -208,11 +213,11 @@ namespace Illusion.Rendering.Shadows
             {
                 data.CasterManager.GetMatrices(i, out Matrix4x4 viewMatrix, out Matrix4x4 projectionMatrix);
 
-                int mainLightIndex = data.LightData.mainLightIndex;
-                VisibleLight mainLight = data.LightData.visibleLights[mainLightIndex];
-                Vector4 shadowBias = ShadowUtils.GetShadowBias(ref mainLight, mainLightIndex, data.ShadowData, projectionMatrix, data.Pass._shadowMap.rt.width);
+                VisibleLight shadowLight = data.LightData.VisibleLight;
+                Vector4 shadowBias = GetDirectionalShadowBias(ref shadowLight, data.ShadowBias,
+                    data.SupportsSoftShadows, projectionMatrix, data.Pass._shadowMap.rt.width);
                 data.ShadowBiases[i] = shadowBias;
-                ShadowUtils.SetupShadowCasterConstantBuffer(cmd, ref mainLight, shadowBias);
+                ShadowUtils.SetupShadowCasterConstantBuffer(cmd, ref shadowLight, shadowBias);
 
                 Vector2Int tilePos = new(i % data.ShadowMapSizeInTile, i / data.ShadowMapSizeInTile);
                 DrawShadow(cmd, data, i, tilePos, in viewMatrix, in projectionMatrix);
@@ -223,6 +228,53 @@ namespace Illusion.Rendering.Shadows
 
             cmd.SetGlobalDepthBias(0.0f, 0.0f);
             CoreUtils.SetKeyword(cmd, KeywordNames._CASTING_SELF_SHADOW, false);
+        }
+
+        // @IllusionRP: URP only populates UniversalShadowData.bias when it allocates a standard shadow atlas.
+        // The per-object atlas remains valid without that atlas, so resolve the same source settings independently.
+        private static Vector2 ResolveShadowBias(Light light, out bool supportsSoftShadows)
+        {
+            UniversalRenderPipelineAsset asset = UniversalRenderPipeline.asset;
+            supportsSoftShadows = asset && asset.supportsSoftShadows;
+
+            if (!light)
+                return Vector2.zero;
+
+            if (light.TryGetComponent(out UniversalAdditionalLightData additionalLightData) &&
+                !additionalLightData.usePipelineSettings)
+                return new Vector2(light.shadowBias, light.shadowNormalBias);
+
+            return asset
+                ? new Vector2(asset.shadowDepthBias, asset.shadowNormalBias)
+                : new Vector2(light.shadowBias, light.shadowNormalBias);
+        }
+
+        private static Vector4 GetDirectionalShadowBias(ref VisibleLight shadowLight, Vector2 bias,
+            bool supportsSoftShadows, Matrix4x4 lightProjectionMatrix, float shadowResolution)
+        {
+            float frustumSize = 2.0f / lightProjectionMatrix.m00;
+            float texelSize = frustumSize / shadowResolution;
+            float depthBias = -bias.x * texelSize;
+            float normalBias = -bias.y * texelSize;
+
+            if (supportsSoftShadows && shadowLight.light.shadows == LightShadows.Soft)
+            {
+                SoftShadowQuality softShadowQuality = SoftShadowQuality.Medium;
+                if (shadowLight.light.TryGetComponent(out UniversalAdditionalLightData additionalLightData))
+                    softShadowQuality = additionalLightData.softShadowQuality;
+
+                float kernelRadius = softShadowQuality switch
+                {
+                    SoftShadowQuality.High => 3.5f,
+                    SoftShadowQuality.Low => 1.5f,
+                    _ => 2.5f
+                };
+
+                depthBias *= kernelRadius;
+                normalBias *= kernelRadius;
+            }
+
+            return new Vector4(depthBias, normalBias, (float)LightType.Directional, 0.0f);
         }
 
         private static void DrawShadow(RasterCommandBuffer cmd, PassData data, int casterIndex, Vector2Int tilePos, in Matrix4x4 view, in Matrix4x4 proj)
@@ -242,6 +294,13 @@ namespace Illusion.Rendering.Shadows
             // Set shadow map texture
             cmd.SetGlobalTexture(PropertyIds.ShadowMap(), data.ShadowmapTexture);
             cmd.SetGlobalInt(PropertyIds.ShadowCount(), data.CasterManager.VisibleCount);
+            cmd.SetGlobalInt(PropertyIds.SourceMode(), (int)data.LightData.Mode);
+            cmd.SetGlobalInt(PropertyIds.AdditionalLightIndex(), data.LightData.AdditionalLightIndex);
+            cmd.SetGlobalVector(PropertyIds.LightDirection(), GetLightDirection(data.LightData));
+            Light source = data.LightData.VisibleLight.light;
+            cmd.SetGlobalVector(PropertyIds.ShadowParams(), new Vector4(
+                source ? source.shadowStrength : 1.0f,
+                source && source.shadows == LightShadows.Soft ? 1.0f : 0.0f, 0.0f, 0.0f));
             cmd.SetGlobalMatrixArray(PropertyIds.ShadowMatrices(), data.ShadowMatrixArray);
             cmd.SetGlobalVectorArray(PropertyIds.ShadowMapRects(), data.ShadowMapRectArray);
             cmd.SetGlobalVectorArray(PropertyIds.ShadowBiases(), data.ShadowBiases);
@@ -308,6 +367,15 @@ namespace Illusion.Rendering.Shadows
             }
         }
 
+        private static Vector4 GetLightDirection(in PerObjectShadowLightData lightData)
+        {
+            if (!lightData.IsValid)
+                return Vector4.zero;
+
+            Vector3 direction = -lightData.VisibleLight.localToWorldMatrix.GetColumn(2);
+            return new Vector4(direction.x, direction.y, direction.z, 0.0f);
+        }
+
         private Matrix4x4 GetShadowMatrix(Vector2Int tilePos, in Matrix4x4 viewMatrix, Matrix4x4 projectionMatrix)
         {
             if (SystemInfo.usesReversedZBuffer)
@@ -364,6 +432,14 @@ namespace Illusion.Rendering.Shadows
 
             private static readonly int _PerObjSceneShadowMapSize = MemberNameHelpers.ShaderPropertyID();
 
+            private static readonly int _PerObjSceneShadowSourceMode = MemberNameHelpers.ShaderPropertyID();
+
+            private static readonly int _PerObjSceneShadowAdditionalLightIndex = MemberNameHelpers.ShaderPropertyID();
+
+            private static readonly int _PerObjSceneShadowLightDirection = MemberNameHelpers.ShaderPropertyID();
+
+            private static readonly int _PerObjSceneShadowParams = MemberNameHelpers.ShaderPropertyID();
+
             // Per-object shadow PCSS parameters
             public static readonly int _PerObjShadowPcssParams0 = MemberNameHelpers.ShaderPropertyID();
             
@@ -390,6 +466,14 @@ namespace Illusion.Rendering.Shadows
             public static int ShadowOffset1() => _PerObjSceneShadowOffset1;
 
             public static int ShadowMapSize() => _PerObjSceneShadowMapSize;
+
+            public static int SourceMode() => _PerObjSceneShadowSourceMode;
+
+            public static int AdditionalLightIndex() => _PerObjSceneShadowAdditionalLightIndex;
+
+            public static int LightDirection() => _PerObjSceneShadowLightDirection;
+
+            public static int ShadowParams() => _PerObjSceneShadowParams;
         }
     }
 }

--- a/Runtime/RenderPipeline/Shadows/PerObjectShadow/PerObjectShadowCasterPreviewPass.cs
+++ b/Runtime/RenderPipeline/Shadows/PerObjectShadow/PerObjectShadowCasterPreviewPass.cs
@@ -35,6 +35,8 @@ namespace Illusion.Rendering.Shadows
         private class PassData
         {
             internal int shadowCountPropertyID;
+            internal int sourceModePropertyID;
+            internal int additionalLightIndexPropertyID;
         }
 
         public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
@@ -42,6 +44,8 @@ namespace Illusion.Rendering.Shadows
             using (var builder = renderGraph.AddRasterRenderPass<PassData>("Per-Object Shadow Preview", out var passData, profilingSampler))
             {
                 passData.shadowCountPropertyID = PerObjectShadowCasterPass.PropertyIds.ShadowCount();
+                passData.sourceModePropertyID = PerObjectShadowCasterPass.PropertyIds.SourceMode();
+                passData.additionalLightIndexPropertyID = PerObjectShadowCasterPass.PropertyIds.AdditionalLightIndex();
                 
                 builder.AllowPassCulling(false);
                 builder.AllowGlobalStateModification(true);
@@ -49,6 +53,8 @@ namespace Illusion.Rendering.Shadows
                 builder.SetRenderFunc((PassData data, RasterGraphContext context) =>
                 {
                     context.cmd.SetGlobalInt(data.shadowCountPropertyID, 0);
+                    context.cmd.SetGlobalInt(data.sourceModePropertyID, (int)PerObjectShadowLightMode.Disabled);
+                    context.cmd.SetGlobalInt(data.additionalLightIndexPropertyID, -1);
                 });
             }
         }

--- a/Runtime/RenderPipeline/Shadows/PerObjectShadow/PerObjectShadowLightSource.cs
+++ b/Runtime/RenderPipeline/Shadows/PerObjectShadow/PerObjectShadowLightSource.cs
@@ -1,0 +1,258 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace Illusion.Rendering.Shadows
+{
+    /// <summary>
+    /// Selects the directional light used to render per-object shadows for this camera.
+    /// A null source follows the camera's current URP main light.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Camera))]
+    public sealed class PerObjectShadowLightSource : MonoBehaviour
+    {
+        [SerializeField]
+        private Light source;
+
+        public Light Source
+        {
+            get => source;
+            set => source = value;
+        }
+    }
+
+    /// <summary>
+    /// Excludes the Per-Object rendering layer from the URP Main Light shadow caster cull when a
+    /// different directional light owns Per-Object shadows for the camera.
+    /// </summary>
+    internal sealed class PerObjectShadowMainLightCasterScope : IDisposable
+    {
+        private bool enabled;
+        private RenderingLayerMask casterRenderingLayers;
+        private Camera activeCamera;
+        private LightShadowState activeState;
+        private bool hasActiveScope;
+
+        private readonly struct LightShadowState
+        {
+            public readonly Light Light;
+            public readonly UniversalAdditionalLightData AdditionalData;
+            public readonly bool CustomShadowLayers;
+            public readonly RenderingLayerMask ShadowRenderingLayers;
+            public readonly int LightRenderingLayerMask;
+
+            public LightShadowState(Light light, UniversalAdditionalLightData additionalData)
+            {
+                Light = light;
+                AdditionalData = additionalData;
+                CustomShadowLayers = additionalData.customShadowLayers;
+                ShadowRenderingLayers = additionalData.shadowRenderingLayers;
+                LightRenderingLayerMask = light.renderingLayerMask;
+            }
+        }
+
+        public PerObjectShadowMainLightCasterScope(bool enabled, RenderingLayerMask renderingLayers)
+        {
+            this.enabled = enabled;
+            casterRenderingLayers = renderingLayers;
+            RenderPipelineManager.endCameraRendering += EndCameraRendering;
+        }
+
+        public void UpdateSettings(bool isEnabled, RenderingLayerMask renderingLayers)
+        {
+            enabled = isEnabled;
+            casterRenderingLayers = renderingLayers;
+            if (!enabled)
+            {
+                RestoreActiveScope();
+            }
+        }
+
+        public void Dispose()
+        {
+            RenderPipelineManager.endCameraRendering -= EndCameraRendering;
+            RestoreActiveScope();
+        }
+
+        public void BeginCameraCull(Camera camera, ScriptableRenderer renderer)
+        {
+            // Recover any scope whose end callback was skipped before applying the next camera's
+            // renderer-owned culling state.
+            RestoreActiveScope();
+
+            uint casterMask = casterRenderingLayers;
+            if (!enabled || casterMask == 0 || !camera ||
+                !camera.TryGetComponent(out PerObjectShadowLightSource selector) ||
+                !selector.isActiveAndEnabled)
+            {
+                return;
+            }
+
+            if (UniversalRenderingUtility.GetRenderingModeActual(renderer) != RenderingMode.ForwardPlus)
+                return;
+
+            Light source = selector.Source;
+            Light mainLight = RenderSettings.sun;
+            if (!PerObjectShadowLightData.IsUsableDirectional(source) ||
+                !PerObjectShadowLightData.IsUsableDirectional(mainLight) || source == mainLight ||
+                !IsVisibleToCamera(camera, source) || !IsVisibleToCamera(camera, mainLight) ||
+                !mainLight.TryGetComponent(out UniversalAdditionalLightData additionalData))
+            {
+                return;
+            }
+
+            var state = new LightShadowState(mainLight, additionalData);
+            RenderingLayerMask effectiveShadowLayers = state.CustomShadowLayers
+                ? state.ShadowRenderingLayers
+                : additionalData.renderingLayers;
+            RenderingLayerMask filteredLayers = (uint)effectiveShadowLayers & ~casterMask;
+
+            // URP snapshots Light.renderingLayerMask during camera culling. This scope must therefore
+            // begin from the owning renderer's pre-cull callback rather than from a ScriptableRenderPass.
+            additionalData.shadowRenderingLayers = filteredLayers;
+            additionalData.customShadowLayers = true;
+            activeCamera = camera;
+            activeState = state;
+            hasActiveScope = true;
+        }
+
+        private void EndCameraRendering(ScriptableRenderContext _, Camera camera)
+        {
+            if (camera == activeCamera)
+            {
+                RestoreActiveScope();
+            }
+        }
+
+        private void RestoreActiveScope()
+        {
+            if (!hasActiveScope)
+            {
+                return;
+            }
+
+            Restore(activeState);
+            activeCamera = null;
+            activeState = default;
+            hasActiveScope = false;
+        }
+
+        private static void Restore(in LightShadowState state)
+        {
+            if (!state.AdditionalData || !state.Light)
+            {
+                return;
+            }
+
+            state.AdditionalData.shadowRenderingLayers = state.ShadowRenderingLayers;
+            state.AdditionalData.customShadowLayers = state.CustomShadowLayers;
+            state.Light.renderingLayerMask = state.LightRenderingLayerMask;
+        }
+
+        private static bool IsVisibleToCamera(Camera camera, Light light)
+        {
+            return light.forceVisible || (camera.cullingMask & (1 << light.gameObject.layer)) != 0;
+        }
+    }
+
+    public enum PerObjectShadowLightMode
+    {
+        Disabled = 0,
+        Main = 1,
+        AdditionalDirectional = 2
+    }
+
+    public readonly struct PerObjectShadowLightData
+    {
+        public readonly PerObjectShadowLightMode Mode;
+        public readonly int AdditionalLightIndex;
+        public readonly VisibleLight VisibleLight;
+
+        public bool IsValid => Mode != PerObjectShadowLightMode.Disabled;
+
+        private PerObjectShadowLightData(PerObjectShadowLightMode mode, int additionalLightIndex,
+            VisibleLight visibleLight)
+        {
+            Mode = mode;
+            AdditionalLightIndex = additionalLightIndex;
+            VisibleLight = visibleLight;
+        }
+
+        public static PerObjectShadowLightData Resolve(UniversalCameraData cameraData,
+            UniversalLightData lightData, bool allowCameraOverride, bool supportsAdditionalDirectional)
+        {
+            var selector = allowCameraOverride
+                ? cameraData.camera.GetComponent<PerObjectShadowLightSource>()
+                : null;
+            Light explicitSource = selector && selector.isActiveAndEnabled ? selector.Source : null;
+            bool hasExplicitSource = explicitSource;
+
+            if (!hasExplicitSource)
+            {
+                int mainIndex = lightData.mainLightIndex;
+                if (mainIndex < 0)
+                    return default;
+
+                VisibleLight main = lightData.visibleLights[mainIndex];
+                return IsUsableDirectional(main.light)
+                    ? new PerObjectShadowLightData(PerObjectShadowLightMode.Main, -1, main)
+                    : default;
+            }
+
+            if (!IsUsableDirectional(explicitSource))
+                return default;
+
+            int visibleIndex = FindVisibleLight(lightData, explicitSource);
+            if (visibleIndex < 0)
+                return default;
+
+            VisibleLight visibleLight = lightData.visibleLights[visibleIndex];
+            if (visibleIndex == lightData.mainLightIndex)
+                return new PerObjectShadowLightData(PerObjectShadowLightMode.Main, -1, visibleLight);
+
+            if (!supportsAdditionalDirectional)
+                return default;
+
+            int additionalIndex = GetAdditionalLightBufferIndex(lightData, visibleIndex);
+            return additionalIndex >= 0 && additionalIndex < lightData.additionalLightsCount
+                ? new PerObjectShadowLightData(PerObjectShadowLightMode.AdditionalDirectional,
+                    additionalIndex, visibleLight)
+                : default;
+        }
+
+        internal static bool IsUsableDirectional(Light light)
+        {
+            return light && light.type == LightType.Directional && light.isActiveAndEnabled &&
+                   light.shadows != LightShadows.None;
+        }
+
+        private static int FindVisibleLight(UniversalLightData lightData, Light source)
+        {
+            for (int i = 0; i < lightData.visibleLights.Length; i++)
+            {
+                if (lightData.visibleLights[i].light == source)
+                    return i;
+            }
+
+            return -1;
+        }
+
+        // Forward+ uploads visible lights in order while omitting the main light.
+        private static int GetAdditionalLightBufferIndex(UniversalLightData lightData, int visibleLightIndex)
+        {
+            int additionalIndex = 0;
+            for (int i = 0; i < lightData.visibleLights.Length; i++)
+            {
+                if (i == lightData.mainLightIndex)
+                    continue;
+                if (i == visibleLightIndex)
+                    return additionalIndex;
+                additionalIndex++;
+            }
+
+            return -1;
+        }
+    }
+}

--- a/Runtime/RenderPipeline/Shadows/PerObjectShadow/PerObjectShadowLightSource.cs.meta
+++ b/Runtime/RenderPipeline/Shadows/PerObjectShadow/PerObjectShadowLightSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d90a16a969f84cf1bd87c708694fbba4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/RenderPipeline/Shadows/PerObjectShadow/ShadowCasterManager.cs
+++ b/Runtime/RenderPipeline/Shadows/PerObjectShadow/ShadowCasterManager.cs
@@ -77,12 +77,13 @@ namespace Illusion.Rendering.Shadows
             }
         }
 
-        public unsafe void Cull(UniversalCameraData cameraData, UniversalLightData lightData, int maxCount, float shadowLengthOffset, bool debugMode)
+        public unsafe void Cull(UniversalCameraData cameraData, in PerObjectShadowLightData lightData,
+            int maxCount, float shadowLengthOffset, bool debugMode)
         {
             m_RendererIndexList.Clear();
             m_CullResults.Reset(maxCount);
 
-            if (s_Casters.Count <= 0 || !TryGetMainLight(lightData, out VisibleLight mainLight))
+            if (s_Casters.Count <= 0 || !lightData.IsValid)
             {
                 return;
             }
@@ -108,7 +109,7 @@ namespace Illusion.Rendering.Shadows
                 DebugMode = debugMode ? 1 : 0,
                 FrustumEightCorners = frustumCorners,
                 CameraLocalToWorldMatrix = cameraTransform.localToWorldMatrix,
-                MainLightLocalToWorldMatrix = mainLight.localToWorldMatrix,
+                MainLightLocalToWorldMatrix = lightData.VisibleLight.localToWorldMatrix,
                 ShadowLengthOffset = shadowLengthOffset
             };
 
@@ -155,18 +156,5 @@ namespace Illusion.Rendering.Shadows
             });
         }
 
-        private static bool TryGetMainLight(in UniversalLightData lightData, out VisibleLight mainLight)
-        {
-            int mainLightIndex = lightData.mainLightIndex;
-
-            if (mainLightIndex < 0)
-            {
-                mainLight = default;
-                return false;
-            }
-
-            mainLight = lightData.visibleLights[mainLightIndex];
-            return mainLight.lightType == LightType.Directional;
-        }
     }
 }

--- a/Runtime/RenderPipeline/Shadows/ScreenSpaceShadows/ScreenSpaceShadowTemporalPass.cs
+++ b/Runtime/RenderPipeline/Shadows/ScreenSpaceShadows/ScreenSpaceShadowTemporalPass.cs
@@ -16,6 +16,7 @@ namespace Illusion.Rendering.Shadows
 
         private readonly int _validateHistoryKernel;
         private readonly int _temporalAccumulationSingleKernel;
+        private readonly int _temporalAccumulationColorKernel;
         private readonly int _copyHistoryKernel;
         private readonly int _compositeContactShadowKernel;
 
@@ -32,6 +33,7 @@ namespace Illusion.Rendering.Shadows
             public int Width;
             public int Height;
             public int ViewCount;
+            public bool Color;
             public float HistoryValidity;
             public float PixelSpreadAngleTangent;
             public Vector4 HistorySizeAndScale;
@@ -80,6 +82,7 @@ namespace Illusion.Rendering.Shadows
             _temporalFilterCS = rendererData.RuntimeResources.temporalFilterCS;
             _validateHistoryKernel = _temporalFilterCS.FindKernel("ValidateHistory");
             _temporalAccumulationSingleKernel = _temporalFilterCS.FindKernel("TemporalAccumulationSingle");
+            _temporalAccumulationColorKernel = _temporalFilterCS.FindKernel("TemporalAccumulationColor");
             _copyHistoryKernel = _temporalFilterCS.FindKernel("CopyHistory");
             _compositeContactShadowKernel = _temporalFilterCS.FindKernel("CompositeContactShadow");
             _diffuseShadowDenoiser = new DiffuseShadowDenoiser(rendererData.RuntimeResources.diffuseShadowDenoiserCS);
@@ -107,11 +110,13 @@ namespace Illusion.Rendering.Shadows
             var resource = frameData.Get<UniversalResourceData>();
             var cameraData = frameData.Get<UniversalCameraData>();
             var lightData = frameData.Get<UniversalLightData>();
+            bool useColorShadow = _rendererData.AdditionalDirectionalPerObjectShadows;
             TextureHandle currentDepthTexture = GetCurrentShadowDepthTexture(frameData, resource);
             TextureHandle currentNormalTexture = resource.cameraNormalsTexture;
 
             TextureHandle sourceShadowTexture = renderGraph.ImportTexture(_rendererData.ScreenSpaceShadowsRT);
-            TextureHandle historyShadowTexture = ImportOrAllocateShadowHistory(renderGraph, out bool shadowHistoryReallocated);
+            TextureHandle historyShadowTexture = ImportOrAllocateShadowHistory(
+                renderGraph, useColorShadow, out bool shadowHistoryReallocated);
             if (!historyShadowTexture.IsValid())
             {
                 return;
@@ -137,7 +142,13 @@ namespace Illusion.Rendering.Shadows
             int height = cameraData.cameraTargetDescriptor.height;
             int viewCount = IllusionRendererData.MaxViewCount;
 
-            float historyValidity = EvaluateHistoryValidity(lightData, hasHistoryDepth, hasHistoryNormal, shadowHistoryReallocated);
+            bool supportsAdditionalDirectional =
+                UniversalRenderingUtility.GetRenderingModeActual(cameraData.renderer) == RenderingMode.ForwardPlus;
+            PerObjectShadowLightData perObjectShadowLight =
+                PerObjectShadowLightData.Resolve(cameraData, lightData,
+                    useColorShadow, supportsAdditionalDirectional);
+            float historyValidity = EvaluateHistoryValidity(lightData, in perObjectShadowLight,
+                hasHistoryDepth, hasHistoryNormal, shadowHistoryReallocated);
             // Screenshot capture warmup needs one valid temporal shadow history before readback.
             ref var captureShadowState = ref _rendererData.CurrentScreenSpaceShadowTemporalState;
             captureShadowState.ActiveThisFrame = true;
@@ -161,26 +172,33 @@ namespace Illusion.Rendering.Shadows
 
             TextureHandle temporalOutputTexture = renderGraph.CreateTexture(new TextureDesc(width, height)
             {
-                colorFormat = GraphicsFormat.R16G16_SFloat,
+                colorFormat = useColorShadow
+                    ? GraphicsFormat.R16G16B16A16_SFloat
+                    : GraphicsFormat.R16G16_SFloat,
                 enableRandomWrite = true,
                 name = "Screen Space Shadow Temporal Output"
             });
-            TextureHandle finalShadowSignalTexture = renderGraph.CreateTexture(new TextureDesc(width, height)
-            {
-                colorFormat = GraphicsFormat.R16_SFloat,
-                enableRandomWrite = true,
-                name = "Screen Space Shadow Temporal Signal"
-            });
+            TextureHandle finalShadowSignalTexture = useColorShadow
+                ? TextureHandle.nullHandle
+                : renderGraph.CreateTexture(new TextureDesc(width, height)
+                {
+                    colorFormat = GraphicsFormat.R16_SFloat,
+                    enableRandomWrite = true,
+                    name = "Screen Space Shadow Temporal Signal"
+                });
 
             using (var builder = renderGraph.AddComputePass<TemporalPassData>("Screen Space Shadow Temporal", out var passData, _temporalSampler))
             {
                 passData.TemporalFilterCS = _temporalFilterCS;
                 passData.ValidateHistoryKernel = _validateHistoryKernel;
-                passData.TemporalAccumulationKernel = _temporalAccumulationSingleKernel;
+                passData.TemporalAccumulationKernel = useColorShadow
+                    ? _temporalAccumulationColorKernel
+                    : _temporalAccumulationSingleKernel;
                 passData.CopyHistoryKernel = _copyHistoryKernel;
                 passData.Width = width;
                 passData.Height = height;
                 passData.ViewCount = viewCount;
+                passData.Color = useColorShadow;
                 passData.HistoryValidity = historyValidity;
                 passData.PixelSpreadAngleTangent = pixelSpreadAngleTangent;
                 passData.HistorySizeAndScale = historySizeAndScale;
@@ -205,7 +223,10 @@ namespace Illusion.Rendering.Shadows
                 builder.UseTexture(passData.HistoryShadowTexture, AccessFlags.ReadWrite);
                 builder.UseTexture(passData.ValidationTexture, AccessFlags.Write);
                 builder.UseTexture(passData.TemporalOutputTexture, AccessFlags.Write);
-                builder.UseTexture(passData.FinalShadowSignalTexture, AccessFlags.Write);
+                if (!passData.Color)
+                {
+                    builder.UseTexture(passData.FinalShadowSignalTexture, AccessFlags.Write);
+                }
 
                 builder.AllowPassCulling(false);
 
@@ -244,27 +265,36 @@ namespace Illusion.Rendering.Shadows
                     context.cmd.SetComputeVectorParam(data.TemporalFilterCS, ShaderProperties.DenoiserResolutionMultiplierVals, data.ResolutionMultiplier);
                     context.cmd.DispatchCompute(data.TemporalFilterCS, data.CopyHistoryKernel, tilesX, tilesY, data.ViewCount);
 
-                    // Extract single-channel shadow signal for downstream passes.
-                    context.cmd.SetComputeTextureParam(data.TemporalFilterCS, data.CopyHistoryKernel, RayTracingShaderProperties.DenoiseInputTexture, data.TemporalOutputTexture);
-                    context.cmd.SetComputeTextureParam(data.TemporalFilterCS, data.CopyHistoryKernel, RayTracingShaderProperties.DenoiseOutputTextureRW, data.FinalShadowSignalTexture);
-                    context.cmd.SetComputeVectorParam(data.TemporalFilterCS, ShaderProperties.DenoiserResolutionMultiplierVals, data.ResolutionMultiplier);
-                    context.cmd.DispatchCompute(data.TemporalFilterCS, data.CopyHistoryKernel, tilesX, tilesY, data.ViewCount);
+                    if (!data.Color)
+                    {
+                        // Extract the single-channel visibility signal from the temporal moments buffer.
+                        context.cmd.SetComputeTextureParam(data.TemporalFilterCS, data.CopyHistoryKernel, RayTracingShaderProperties.DenoiseInputTexture, data.TemporalOutputTexture);
+                        context.cmd.SetComputeTextureParam(data.TemporalFilterCS, data.CopyHistoryKernel, RayTracingShaderProperties.DenoiseOutputTextureRW, data.FinalShadowSignalTexture);
+                        context.cmd.SetComputeVectorParam(data.TemporalFilterCS, ShaderProperties.DenoiserResolutionMultiplierVals, data.ResolutionMultiplier);
+                        context.cmd.DispatchCompute(data.TemporalFilterCS, data.CopyHistoryKernel, tilesX, tilesY, data.ViewCount);
+                    }
                 });
             }
 
-            TextureHandle finalShadowTexture = finalShadowSignalTexture;
+            TextureHandle finalShadowTexture = useColorShadow
+                ? temporalOutputTexture
+                : finalShadowSignalTexture;
             if (pcssParams.shadowSpatialDenoise.value)
             {
                 TextureHandle denoiseIntermediate = renderGraph.CreateTexture(new TextureDesc(width, height)
                 {
-                    colorFormat = GraphicsFormat.R16_SFloat,
+                    colorFormat = useColorShadow
+                        ? GraphicsFormat.R16G16B16A16_SFloat
+                        : GraphicsFormat.R16_SFloat,
                     enableRandomWrite = true,
                     name = "Screen Space Shadow Spatial Intermediate"
                 });
 
                 TextureHandle denoiseOutput = renderGraph.CreateTexture(new TextureDesc(width, height)
                 {
-                    colorFormat = GraphicsFormat.R16_SFloat,
+                    colorFormat = useColorShadow
+                        ? GraphicsFormat.R16G16B16A16_SFloat
+                        : GraphicsFormat.R16_SFloat,
                     enableRandomWrite = true,
                     name = "Screen Space Shadow Spatial Output"
                 });
@@ -273,10 +303,10 @@ namespace Illusion.Rendering.Shadows
                 float cameraFovRadians = cameraData.camera.fieldOfView * Mathf.Deg2Rad;
                 _diffuseShadowDenoiser.DenoiseBuffer(renderGraph,
                     currentDepthTexture, currentNormalTexture,
-                    finalShadowSignalTexture, denoiseIntermediate, denoiseOutput,
+                    finalShadowTexture, denoiseIntermediate, denoiseOutput,
                     width, height, viewCount,
                     lightAngleRadians, cameraFovRadians, pcssParams.shadowDenoiseKernelSize.value,
-                    _spatialSampler);
+                    _spatialSampler, color: useColorShadow);
 
                 finalShadowTexture = denoiseOutput;
             }
@@ -286,7 +316,9 @@ namespace Illusion.Rendering.Shadows
             {
                 TextureHandle contactCompositeTexture = renderGraph.CreateTexture(new TextureDesc(width, height)
                 {
-                    colorFormat = GraphicsFormat.R16_SFloat,
+                    colorFormat = useColorShadow
+                        ? GraphicsFormat.R16G16_SFloat
+                        : GraphicsFormat.R16_SFloat,
                     enableRandomWrite = true,
                     name = "Screen Space Shadow Contact Composite"
                 });
@@ -369,17 +401,22 @@ namespace Illusion.Rendering.Shadows
                 : TextureHandle.nullHandle;
         }
 
-        private TextureHandle ImportOrAllocateShadowHistory(RenderGraph renderGraph, out bool wasAllocated)
+        private TextureHandle ImportOrAllocateShadowHistory(
+            RenderGraph renderGraph, bool useColorShadow, out bool wasAllocated)
         {
             var historyRT = _rendererData.GetCurrentFrameRT((int)IllusionFrameHistoryType.ScreenSpaceShadowHistory);
-            wasAllocated = historyRT == null || !historyRT.IsValid();
+            GraphicsFormat historyFormat = useColorShadow
+                ? GraphicsFormat.R16G16B16A16_SFloat
+                : GraphicsFormat.R16G16_SFloat;
+            wasAllocated = historyRT == null || !historyRT.IsValid() ||
+                           historyRT.rt.graphicsFormat != historyFormat;
             if (wasAllocated)
             {
                 _rendererData.ReleaseHistoryFrameRT((int)IllusionFrameHistoryType.ScreenSpaceShadowHistory);
 
                 var allocator = new IllusionRendererData.CustomHistoryAllocator(
                     Vector2.one,
-                    GraphicsFormat.R16G16_SFloat,
+                    historyFormat,
                     "ScreenSpaceShadowHistory");
                 historyRT = _rendererData.AllocHistoryFrameRT((int)IllusionFrameHistoryType.ScreenSpaceShadowHistory, allocator.Allocator, 1);
             }
@@ -387,7 +424,9 @@ namespace Illusion.Rendering.Shadows
             return historyRT != null && historyRT.IsValid() ? renderGraph.ImportTexture(historyRT) : TextureHandle.nullHandle;
         }
 
-        private float EvaluateHistoryValidity(UniversalLightData lightData, bool hasHistoryDepth, bool hasHistoryNormal, bool shadowHistoryReallocated)
+        private float EvaluateHistoryValidity(UniversalLightData lightData,
+            in PerObjectShadowLightData perObjectShadowLight, bool hasHistoryDepth, bool hasHistoryNormal,
+            bool shadowHistoryReallocated)
         {
             ref var shadowState = ref _rendererData.CurrentScreenSpaceShadowTemporalState;
             float historyValidity = 1.0f;
@@ -400,19 +439,32 @@ namespace Illusion.Rendering.Shadows
             }
 
             Vector3 currentMainLightDirection = lightData.visibleLights[mainLightIndex].light.transform.forward;
+            Light currentPerObjectLight = perObjectShadowLight.VisibleLight.light;
+            int currentPerObjectLightId = currentPerObjectLight ? currentPerObjectLight.GetInstanceID() : 0;
+            Vector3 currentPerObjectLightDirection = currentPerObjectLight
+                ? currentPerObjectLight.transform.forward
+                : Vector3.zero;
             bool lightDirectionChanged = !shadowState.HasDirectionalHistoryState
                                          || (currentMainLightDirection - shadowState.LastMainLightDirection).sqrMagnitude > 1e-6f;
+            bool perObjectLightChanged = !shadowState.HasDirectionalHistoryState
+                                         || shadowState.LastPerObjectShadowMode != perObjectShadowLight.Mode
+                                         || shadowState.LastPerObjectLightId != currentPerObjectLightId
+                                         || (currentPerObjectLightDirection - shadowState.LastPerObjectLightDirection)
+                                         .sqrMagnitude > 1e-6f;
             bool nonConsecutiveFrame = !shadowState.HasDirectionalHistoryState
                                        || (shadowState.LastHistoryFrameCount + 1) != _rendererData.FrameCount;
             bool invalidByFrame = _rendererData.IsFirstFrame || _rendererData.ResetPostProcessingHistory || nonConsecutiveFrame;
             bool invalidByHistoryResources = !hasHistoryDepth || !hasHistoryNormal || shadowHistoryReallocated;
 
-            if (lightDirectionChanged || invalidByFrame || invalidByHistoryResources)
+            if (lightDirectionChanged || perObjectLightChanged || invalidByFrame || invalidByHistoryResources)
             {
                 historyValidity = 0.0f;
             }
 
             shadowState.LastMainLightDirection = currentMainLightDirection;
+            shadowState.LastPerObjectShadowMode = perObjectShadowLight.Mode;
+            shadowState.LastPerObjectLightId = currentPerObjectLightId;
+            shadowState.LastPerObjectLightDirection = currentPerObjectLightDirection;
             shadowState.LastHistoryFrameCount = _rendererData.FrameCount;
             shadowState.HasDirectionalHistoryState = true;
             return historyValidity;

--- a/Runtime/RenderPipeline/Shadows/ScreenSpaceShadows/ScreenSpaceShadowsPass.cs
+++ b/Runtime/RenderPipeline/Shadows/ScreenSpaceShadows/ScreenSpaceShadowsPass.cs
@@ -132,8 +132,11 @@ namespace Illusion.Rendering.Shadows
             
             descriptor.depthBufferBits = 0;
             descriptor.msaaSamples = 1;
-            descriptor.graphicsFormat = SystemInfo.IsFormatSupported(GraphicsFormat.R8_UNorm, GraphicsFormatUsage.Blend)
-                ? GraphicsFormat.R8_UNorm
+            GraphicsFormat preferredFormat = _rendererData.AdditionalDirectionalPerObjectShadows
+                ? GraphicsFormat.R8G8_UNorm
+                : GraphicsFormat.R8_UNorm;
+            descriptor.graphicsFormat = SystemInfo.IsFormatSupported(preferredFormat, GraphicsFormatUsage.Blend)
+                ? preferredFormat
                 : GraphicsFormat.B8G8R8A8_UNorm;
 
             // Keep a persistent screen space shadow texture so temporal accumulation can run in a follow-up pass.

--- a/ShaderLibrary/RealtimeLights.hlsl
+++ b/ShaderLibrary/RealtimeLights.hlsl
@@ -33,9 +33,28 @@ Light IllusionGetMainLight(InputData inputData, half4 shadowMask)
 }
 
 // AO has been separated for diffuse and specular, so it will be applied in lighting.
-Light IllusionGetAdditionalLight(uint i, InputData inputData, half4 shadowMask)
+Light IllusionGetAdditionalLight(uint i, InputData inputData, half4 shadowMask, bool receivePerObjectShadow)
 {
     Light light = GetAdditionalLight(i, inputData.positionWS, shadowMask);
+#if USE_CLUSTER_LIGHT_LOOP
+    if (receivePerObjectShadow &&
+        _PerObjSceneShadowSourceMode == PER_OBJECT_SHADOW_SOURCE_ADDITIONAL_DIRECTIONAL &&
+        (int)i == _PerObjSceneShadowAdditionalLightIndex)
+    {
+#if defined(_MAIN_LIGHT_SHADOWS_SCREEN) && (SURFACE_TYPE_RECEIVE_SCREEN_SPACE_SHADOWS)
+        float perObjectVisibility = IllusionAdditionalPerObjectScreenSpaceShadow(inputData.shadowCoord);
+#else
+        float perObjectVisibility = PerObjectDirectionalShadow(
+            inputData.positionWS, inputData.normalWS, light.direction);
+#endif
+        light.shadowAttenuation = min(light.shadowAttenuation, perObjectVisibility);
+    }
+#endif
     return light;
+}
+
+Light IllusionGetAdditionalLight(uint i, InputData inputData, half4 shadowMask)
+{
+    return IllusionGetAdditionalLight(i, inputData, shadowMask, true);
 }
 #endif

--- a/ShaderLibrary/Shadow/HDPerObjectShadow.hlsl
+++ b/ShaderLibrary/Shadow/HDPerObjectShadow.hlsl
@@ -163,10 +163,10 @@ float PerObjectShadowHD(
         shadowCoord, shadowSamplingData, shadowParams, isPerspectiveProjection, screenCoord, shadowIndex, shadowMapRects);
 }
 
-float MainLightPerObjectSceneShadow(float3 positionWS, float3 normalWS, half3 lightDir, float2 screenCoord)
+float PerObjectDirectionalShadowHD(float3 positionWS, float3 normalWS, half3 lightDir, float2 screenCoord)
 {
     ShadowSamplingData shadowSamplingData = GetMainLightPerObjectSceneShadowSamplingData();
-    half4 shadowParams = GetMainLightShadowParams();
+    half4 shadowParams = _PerObjSceneShadowParams;
     float shadow = 1;
 
     for (int i = 0; i < _PerObjSceneShadowCount; i++)
@@ -182,5 +182,12 @@ float MainLightPerObjectSceneShadow(float3 positionWS, float3 normalWS, half3 li
     }
 
     return shadow;
+}
+
+float MainLightPerObjectSceneShadow(float3 positionWS, float3 normalWS, half3 lightDir, float2 screenCoord)
+{
+    return _PerObjSceneShadowSourceMode == PER_OBJECT_SHADOW_SOURCE_MAIN
+        ? PerObjectDirectionalShadowHD(positionWS, normalWS, lightDir, screenCoord)
+        : 1.0;
 }
 #endif

--- a/ShaderLibrary/Shadow/PerObjectShadow.hlsl
+++ b/ShaderLibrary/Shadow/PerObjectShadow.hlsl
@@ -31,6 +31,9 @@ TEXTURE2D_SHADOW(_PerObjSceneShadowMap);
 SAMPLER_CMP(sampler_PerObjSceneShadowMap);
 
 int _PerObjSceneShadowCount;
+int _PerObjSceneShadowSourceMode;
+int _PerObjSceneShadowAdditionalLightIndex;
+float4 _PerObjSceneShadowLightDirection;
 float4x4 _PerObjSceneShadowMatrices[MAX_PER_OBJECT_SHADOW_COUNT];
 float4 _PerObjSceneShadowMapRects[MAX_PER_OBJECT_SHADOW_COUNT];
 float _PerObjSceneShadowCasterIds[MAX_PER_OBJECT_SHADOW_COUNT];
@@ -39,6 +42,11 @@ float4 _PerObjShadowBiases[MAX_PER_OBJECT_SHADOW_COUNT];
 float4 _PerObjSceneShadowOffset0;
 float4 _PerObjSceneShadowOffset1;
 float4 _PerObjSceneShadowMapSize;
+half4 _PerObjSceneShadowParams;
+
+#define PER_OBJECT_SHADOW_SOURCE_DISABLED 0
+#define PER_OBJECT_SHADOW_SOURCE_MAIN 1
+#define PER_OBJECT_SHADOW_SOURCE_ADDITIONAL_DIRECTIONAL 2
 
 float4 TransformWorldToPerObjectShadowCoord(float4x4 shadowMatrix, float3 positionWS)
 {
@@ -137,7 +145,7 @@ ShadowSamplingData GetMainLightPerObjectSceneShadowSamplingData()
 
     // shadowmapSize is used in SampleShadowmapFiltered otherwise
     shadowSamplingData.shadowmapSize = _PerObjSceneShadowMapSize;
-    shadowSamplingData.softShadowQuality = _MainLightShadowParams.y;
+    shadowSamplingData.softShadowQuality = _PerObjSceneShadowParams.y;
 
     return shadowSamplingData;
 }
@@ -156,10 +164,10 @@ float3 ApplyPerObjectShadowBias(float3 positionWS, float3 normalWS, float3 light
     return positionWS;
 }
 
-float MainLightPerObjectSceneShadow(float3 positionWS, float3 normalWS, half3 lightDir)
+float PerObjectDirectionalShadow(float3 positionWS, float3 normalWS, half3 lightDir)
 {
     ShadowSamplingData shadowSamplingData = GetMainLightPerObjectSceneShadowSamplingData();
-    half4 shadowParams = GetMainLightShadowParams();
+    half4 shadowParams = _PerObjSceneShadowParams;
     float shadow = 1;
 
     for (int i = 0; i < _PerObjSceneShadowCount; i++)
@@ -175,6 +183,13 @@ float MainLightPerObjectSceneShadow(float3 positionWS, float3 normalWS, half3 li
     }
 
     return shadow;
+}
+
+float MainLightPerObjectSceneShadow(float3 positionWS, float3 normalWS, half3 lightDir)
+{
+    return _PerObjSceneShadowSourceMode == PER_OBJECT_SHADOW_SOURCE_MAIN
+        ? PerObjectDirectionalShadow(positionWS, normalWS, lightDir)
+        : 1.0;
 }
 
 #endif

--- a/ShaderLibrary/Shadow/Shadows.hlsl
+++ b/ShaderLibrary/Shadow/Shadows.hlsl
@@ -99,6 +99,19 @@ half IllusionMainLightRealtimeShadow(float4 shadowCoord)
 #endif
 }
 
+half IllusionAdditionalPerObjectScreenSpaceShadow(float4 shadowCoord)
+{
+    shadowCoord.xy /= max(0.00001, shadowCoord.w);
+    shadowCoord.xy = UnityStereoTransformScreenSpaceTex(shadowCoord.xy);
+
+#if defined(UNITY_STEREO_INSTANCING_ENABLED) || defined(UNITY_STEREO_MULTIVIEW_ENABLED)
+    return SAMPLE_TEXTURE2D_ARRAY(_ScreenSpaceShadowmapTexture, sampler_PointClamp, shadowCoord.xy,
+        unity_StereoEyeIndex).y;
+#else
+    return SAMPLE_TEXTURE2D(_ScreenSpaceShadowmapTexture, sampler_PointClamp, shadowCoord.xy).y;
+#endif
+}
+
 // Fragment shader lighting pass
 half IllusionMainLightShadow(float4 shadowCoord, float3 positionWS, float3 normalWS, half3 lightDir, half4 shadowMask, half4 occlusionProbeChannels)
 {

--- a/Shaders/Hair/Lighting.hlsl
+++ b/Shaders/Hair/Lighting.hlsl
@@ -493,7 +493,9 @@ half4 HairPBR(InputData inputData, SurfaceData surfaceData, HairData HairData)
     {
         CLUSTER_LIGHT_LOOP_SUBTRACTIVE_LIGHT_CHECK
 
-        Light light = IllusionGetAdditionalLight(lightIndex, inputData, shadowMask);
+        // Alpha-card hair remains a caster, but skips the selected additional
+        // directional per-object receiver overlay to avoid self-shadow banding.
+        Light light = IllusionGetAdditionalLight(lightIndex, inputData, shadowMask, false);
 
     #ifdef _LIGHT_LAYERS
         if (IsMatchingLightLayer(light.layerMask, meshRenderingLayers))
@@ -506,7 +508,7 @@ half4 HairPBR(InputData inputData, SurfaceData surfaceData, HairData HairData)
     #endif
 
     LIGHT_LOOP_BEGIN(pixelLightCount)
-        Light light = IllusionGetAdditionalLight(lightIndex, inputData, shadowMask);
+        Light light = IllusionGetAdditionalLight(lightIndex, inputData, shadowMask, false);
 
         #ifdef _LIGHT_LAYERS
         if (IsMatchingLightLayer(light.layerMask, meshRenderingLayers))

--- a/Shaders/ScreenSpaceLighting/ScreenSpaceShadows.shader
+++ b/Shaders/ScreenSpaceLighting/ScreenSpaceShadows.shader
@@ -78,40 +78,46 @@ Shader "Hidden/ScreenSpaceShadows"
                 float3 positionWS = ComputeWorldSpacePosition(input.texcoord.xy, deviceDepth, unity_MatrixInvVP);
 
                 float3 biasPositionWS = positionWS;
-                float3 lightDir = GetMainLight().direction;
+                float3 mainLightDir = GetMainLight().direction;
+                float3 perObjectLightDir = _PerObjSceneShadowLightDirection.xyz;
                 float3 normalWS = 0;
 #if APPLY_SHADOW_BIAS_FRAGMENT
                 normalWS = LoadSceneNormals(input.positionCS.xy);
-                biasPositionWS = IllusionApplyShadowBias(positionWS, normalWS, lightDir);
+                biasPositionWS = IllusionApplyShadowBias(positionWS, normalWS, mainLightDir);
 #endif
 
                 // Screenspace shadowmap is only used for directional lights which use orthogonal projection.
                 half realtimeShadow = IllusionMainLightRealtimeShadow(TransformWorldToShadowCoordCascade(biasPositionWS), input.texcoord.xy);
-                float perObjShadow = MainLightPerObjectSceneShadow(positionWS, normalWS, lightDir, input.texcoord.xy);
+                float perObjShadow = PerObjectDirectionalShadowHD(positionWS, normalWS, perObjectLightDir, input.texcoord.xy);
+
+                float mainShadow = realtimeShadow;
+                float additionalPerObjectShadow = 1.0;
+                if (_PerObjSceneShadowSourceMode == PER_OBJECT_SHADOW_SOURCE_MAIN)
+                    mainShadow = min(mainShadow, perObjShadow);
+                else if (_PerObjSceneShadowSourceMode == PER_OBJECT_SHADOW_SOURCE_ADDITIONAL_DIRECTIONAL)
+                    additionalPerObjectShadow = perObjShadow;
 
                 // TODO: Let contact shadow map always exist and be white default
 #ifdef _CONTACT_SHADOWS
-				float screenSpaceShadow = min(realtimeShadow, perObjShadow);
 				float contactShadow = 1 - LOAD_TEXTURE2D_X(_ContactShadowMap, input.positionCS.xy).r;
-            	float finalShadow = _IncludeContactShadow != 0.0 ? min(contactShadow, screenSpaceShadow) : screenSpaceShadow;
-#else
-                float finalShadow = min(realtimeShadow, perObjShadow);
+				if (_IncludeContactShadow != 0.0)
+                    mainShadow = min(contactShadow, mainShadow);
 #endif
 
                 // Debug mode
 #if defined(_DEBUG_SCREEN_SPACE_SHADOW_MAINLIGHT)
-                // Only display main light shadow (realtime shadow + per object shadow)
-                return min(realtimeShadow, perObjShadow);
+                return half4(mainShadow, 1.0, 1.0, 1.0);
 #elif defined(_DEBUG_SCREEN_SPACE_SHADOW_CONTACT)
                 // Only display contact shadow
 #ifdef _CONTACT_SHADOWS
-                return 1 - LOAD_TEXTURE2D_X(_ContactShadowMap, input.positionCS.xy).r;
+                float contactShadowDebug = 1 - LOAD_TEXTURE2D_X(_ContactShadowMap, input.positionCS.xy).r;
+                return half4(contactShadowDebug, 1.0, 1.0, 1.0);
 #else
-                return 1.0; // No contact shadow, return white
+                return half4(1.0, 1.0, 1.0, 1.0); // No contact shadow, return white
 #endif
 #else
-                // Normal mode
-                return finalShadow;
+                // R stores Main visibility; G stores the selected Additional Directional visibility.
+                return half4(mainShadow, additionalPerObjectShadow, 1.0, 1.0);
 #endif
             }
             ENDHLSL

--- a/Shaders/ScreenSpaceLighting/TemporalFilter.compute
+++ b/Shaders/ScreenSpaceLighting/TemporalFilter.compute
@@ -326,9 +326,13 @@ void CompositeContactShadow(uint3 dispatchThreadId : SV_DispatchThreadID)
     if (any(dispatchThreadId.xy >= (uint2)round((float2)_ScreenSize.xy * _DenoiserResolutionMultiplierVals.xx)))
         return;  // Out of bounds, discard
 
-    float screenSpaceShadow = LOAD_TEXTURE2D_X(_DenoiseInputTexture, dispatchThreadId.xy).x;
+    float2 screenSpaceShadow = LOAD_TEXTURE2D_X(_DenoiseInputTexture, dispatchThreadId.xy).xy;
     float contactShadow = 1.0 - LOAD_TEXTURE2D_X(_ContactShadowMap, dispatchThreadId.xy).r;
-    _DenoiseOutputTextureRW[COORD_TEXTURE2D_X(dispatchThreadId.xy)] = float4(min(screenSpaceShadow, contactShadow), 0.0, 0.0, 1.0);
+    float2 compositedShadow = float2(
+        min(screenSpaceShadow.x, contactShadow),
+        screenSpaceShadow.y);
+    _DenoiseOutputTextureRW[COORD_TEXTURE2D_X(dispatchThreadId.xy)] =
+        float4(compositedShadow, 0.0, 1.0);
 }
 
 // Output is array textures


### PR DESCRIPTION
### Summary

This PR allows each camera to select a directional light as its per-object shadow source. The selected light may be either the URP Main Light or a Forward+ additional directional light.

### Main shadow correctness

Previously, IllusionRP modified the URP Main Light’s shadow rendering layers and did not restore them. This could remove character casters from the Main Shadow Atlas, affect standard URP shadow consumers, and leave the Light in a modified runtime state.

The new implementation:

- Keeps the Main Shadow Atlas complete when using Main Light fallback.
- Applies caster exclusion only when an additional directional light owns character per-object shadows.
- Limits that exclusion to the current camera’s culling scope.
- Restores all Light shadow-layer settings after rendering.
- Preserves standard shadows for transparent, volumetric, PRT, off-screen, and third-party URP consumers.

Main fallback may draw registered character casters in both atlases. This duplication is intentional to preserve compatibility.

### Rendering changes

- Adds the camera-level `PerObjectShadowLightSource` component.
- Stores Main visibility in the screen-space shadow R channel and selected Additional visibility in G.
- Applies PCSS temporal and spatial filtering to both channels.
- Keeps Contact Shadows associated with the Main Light.
- Prevents dense alpha-card hair from receiving the Additional per-object self-shadow overlay while retaining it as a caster.